### PR TITLE
fix(tekton): correct dockerfile path and build context for maas-controller v3-4

### DIFF
--- a/.tekton/odh-maas-controller-v3-4-push.yaml
+++ b/.tekton/odh-maas-controller-v3-4-push.yaml
@@ -32,9 +32,9 @@ spec:
   - name: rhoai-version
     value: "3.4.0"
   - name: dockerfile
-    value: Dockerfile.konflux
+    value: maas-controller/Dockerfile.konflux
   - name: path-context
-    value: maas-controller
+    value: .
   - name: hermetic
     value: true
   - name: prefetch-input


### PR DESCRIPTION
## Summary
Fix the incorrect Dockerfile context path for the maas-controller Tekton pipeline on the rhoai-3.4 branch.

## Description
The `odh-maas-controller-v3-4-push.yaml` pipeline had `path-context: maas-controller` and `dockerfile: Dockerfile.konflux`, which sets the build context to the `maas-controller/` subdirectory. However, `maas-controller/Dockerfile.konflux` contains `COPY` instructions that reference paths outside that directory (`maas-api/deploy`, `deployment/base/...`), causing the build to fail.

- Change `path-context` from `maas-controller` to `.` (repo root).
- Change `dockerfile` from `Dockerfile.konflux` to `maas-controller/Dockerfile.konflux`.
- Aligns with the upstream main branch Tekton configuration pattern.

## How it was tested
- Verified that `maas-controller/Dockerfile.konflux` references paths relative to the repo root (`maas-controller/go.mod`, `maas-api/deploy`, `deployment/base/...`).
- Confirmed the fix matches the working upstream main branch Tekton pattern.

Made with [Cursor](https://cursor.com)