### PR TITLE
fix(cve): cve-2026-33815 - pgx memory-safety

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/models-as-a-service/maas-api
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/gin-contrib/cors v1.7.6
@@ -20,7 +20,7 @@ require (
 )
 
 require (
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.0
 	github.com/mattn/go-sqlite3 v1.14.32
 )
 
@@ -104,7 +104,6 @@ require (
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -214,8 +214,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
+github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=


### PR DESCRIPTION
## summary

update github.com/jackc/pgx/v5 from v5.7.6 to v5.9.0 to resolve memory-safety vulnerability (cve-2026-33815).

## cve details

- **cve id**: cve-2026-33815
- **package**: github.com/jackc/pgx/v5
- **vulnerable versions**: < v5.9.0
- **fixed version**: v5.9.0
- **jira**: rhoaieng-57067

## changes

- update `github.com/jackc/pgx/v5` from v5.7.6 to v5.9.0 in `maas-api/go.mod`
- run `go mod tidy` to update `maas-api/go.sum`

## test results

tests running - will update once completed

## test plan

- [x] govulncheck confirms cve no longer present
- [ ] ci/cd pipeline passes

---

🤖 generated with [claude code](https://claude.com/claude-code)
<!-- cve-fixer-workflow -->