### PR TITLE
fix(cve): cve-2026-34986 - go-jose dos

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.2 // indirect

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -124,8 +124,8 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.10.1 h1:T0ujvqyCSqRopADpgPgiTT63DUQVSfojyME59Ei63pQ=
 github.com/gin-gonic/gin v1.10.1/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
-github.com/go-jose/go-jose/v4 v4.1.1 h1:JYhSgy4mXXzAdF3nUx3ygx347LRXJRrpgyU3adRmkAI=
-github.com/go-jose/go-jose/v4 v4.1.1/go.mod h1:BdsZGqgdO3b6tTc6LSE56wcDbMMLuPsw5d4ZD5f94kA=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## summary

update github.com/go-jose/go-jose/v4 from v4.1.1 to v4.1.4 to resolve denial of service vulnerability via crafted jwe object (cve-2026-34986).

## cve details

- **cve id**: cve-2026-34986
- **package**: github.com/go-jose/go-jose/v4
- **severity**: high (cvss 7.5)
- **vulnerable versions**: < v4.1.4
- **fixed version**: v4.1.4
- **jira**: rhoaieng-56853

## changes

- update `github.com/go-jose/go-jose/v4` from v4.1.1 to v4.1.4 in `maas-api/go.mod`
- run `go mod tidy` to update `maas-api/go.sum`

## test plan

- [x] dependency version verified at v4.1.4
- [ ] ci/cd pipeline passes

---

🤖 generated with [claude code](https://claude.com/claude-code)
<!-- cve-fixer-workflow -->