### PR TITLE
chore: sync rhoai-3.4 with main

### DIFF
--- a/.github/hack/install-odh.sh
+++ b/.github/hack/install-odh.sh
@@ -208,7 +208,9 @@ EOF
   fi
 fi
 
-# 7. Apply DataScienceCluster (modelsAsService Unmanaged - MaaS deployed separately)
+# 7. Apply DataScienceCluster (KServe + ModelsAsService Managed)
+# The manifest filename retains "unmanaged" for backward compat; contents include
+# modelsAsService.managementState: Managed so the operator deploys maas-controller.
 echo "7. Applying DataScienceCluster..."
 if kubectl get datasciencecluster -A --no-headers 2>/dev/null | grep -q .; then
   echo "   DataScienceCluster already exists, skipping"

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ apps/backend/.env
 CLAUDE.md
 .cursor/
 
+# Git worktrees
+.worktrees/
+
 # Docs build and site directories
 docs/build/
 docs/site/

--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
@@ -82,15 +82,8 @@ spec:
                 pattern: ^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)*$
                 type: string
               provider:
-                description: |-
-                  Provider identifies the API format and auth type for the external model.
-                  The allowed values are: "openai", "anthropic", "azure-openai", "vertex" and "bedrock-openai".
-                enum:
-                - openai
-                - anthropic
-                - azure-openai
-                - vertex
-                - bedrock-openai
+                description: Provider identifies the API format and auth type for
+                  the external model.
                 maxLength: 63
                 minLength: 1
                 type: string

--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maassubscriptions.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maassubscriptions.yaml
@@ -83,8 +83,11 @@ spec:
                         description: TokenRateLimit defines a token rate limit
                         properties:
                           limit:
-                            description: Limit is the maximum number of tokens allowed
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
                             format: int64
+                            maximum: 1000000000
                             minimum: 1
                             type: integer
                           window:

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -21,7 +21,6 @@ rules:
   resources:
   - endpoints
   - pods
-  - secrets
   verbs:
   - get
   - list
@@ -35,6 +34,21 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - maas-db-config
+  resources:
+  - secrets
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:

--- a/deployment/base/payload-processing/rbac/clusterrole.yaml
+++ b/deployment/base/payload-processing/rbac/clusterrole.yaml
@@ -13,5 +13,5 @@ rules:
     verbs: ["get", "list", "watch"]
   # model-provider-resolver plugin: watches ExternalModel CRDs across namespaces
   - apiGroups: ["maas.opendatahub.io"]
-    resources: ["maasmodelrefs", "externalmodels"]
+    resources: ["externalmodels"]
     verbs: ["get", "list", "watch"]

--- a/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
+++ b/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
@@ -81,7 +81,29 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: kuadrant-prometheus-datasource
-                  query: 'count(count by (user) (increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]) > 0)) or vector(0)'
+                  query: |-
+                    count(
+                      count by (user) (
+                        (
+                          (
+                            sum by (user, subscription, limitador_namespace) (
+                              increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                            )
+                            +
+                            sum by (user, subscription, limitador_namespace) (
+                              increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                            )
+                          )
+                          or
+                          sum by (user, subscription, limitador_namespace) (
+                            increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                          )
+                        )
+                        * on(user, subscription, limitador_namespace)
+                        (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                        > 0
+                      )
+                    ) or vector(0)
                   seriesNameFormat: Users
     successRate:
       kind: Panel
@@ -105,7 +127,41 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: kuadrant-prometheus-datasource
-                  query: '((sum(increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))) / ((sum(increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) + (sum(increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) or vector(0))) > 0)) or vector(1)'
+                  query: |-
+                    (
+                      (
+                        sum(
+                          sum by (user, subscription, limitador_namespace) (
+                            increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                          )
+                          * on(user, subscription, limitador_namespace)
+                          (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                        )
+                      )
+                      /
+                      (
+                        (
+                          sum(
+                            sum by (user, subscription, limitador_namespace) (
+                              increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                            )
+                            * on(user, subscription, limitador_namespace)
+                            (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                          )
+                          +
+                          (
+                            sum(
+                              sum by (user, subscription, limitador_namespace) (
+                                increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                              )
+                              * on(user, subscription, limitador_namespace)
+                              (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                            )
+                            or vector(0)
+                          )
+                        ) > 0
+                      )
+                    ) or vector(1)
                   seriesNameFormat: Success Rate
     tokenConsumptionByUser:
       kind: Panel
@@ -180,7 +236,15 @@ spec:
                   query: |-
                     round(
                       sum by (user, subscription, model) (
-                        sum by (user, subscription, limitador_namespace) (increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))
+                        (
+                          (
+                            sum by (user, subscription, limitador_namespace) (increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))
+                            +
+                            sum by (user, subscription, limitador_namespace) (increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))
+                          )
+                          or
+                          sum by (user, subscription, limitador_namespace) (increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))
+                        )
                         * on(user, subscription, limitador_namespace) group_left(model)
                         (0 * max by (user, subscription, limitador_namespace, model) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
                       )
@@ -228,7 +292,15 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: kuadrant-prometheus-datasource
-                  query: 'sum(increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) or vector(0)'
+                  query: |-
+                    sum(
+                      sum by (user, subscription, limitador_namespace) (
+                        increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                      )
+                      * on(user, subscription, limitador_namespace)
+                      (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                    )
+                    or vector(0)
                   seriesNameFormat: Errors
     totalRequests:
       kind: Panel
@@ -253,7 +325,28 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: kuadrant-prometheus-datasource
-                  query: '(sum(increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) or vector(0)) + (sum(increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) or vector(0))'
+                  query: |-
+                    (
+                      sum(
+                        sum by (user, subscription, limitador_namespace) (
+                          increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                        )
+                        * on(user, subscription, limitador_namespace)
+                        (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                      )
+                      or vector(0)
+                    )
+                    +
+                    (
+                      sum(
+                        sum by (user, subscription, limitador_namespace) (
+                          increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                        )
+                        * on(user, subscription, limitador_namespace)
+                        (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                      )
+                      or vector(0)
+                    )
                   seriesNameFormat: Requests
     totalTokens:
       kind: Panel

--- a/docs/content/advanced-administration/observability.md
+++ b/docs/content/advanced-administration/observability.md
@@ -144,18 +144,19 @@ The observability stack consists of:
 
 There are two ways to enable deployment-based observability:
 
-1. **Operator-managed** (recommended): Enable via ModelsAsService CR
+1. **Operator-managed** (recommended): Enable via Tenant CR
 2. **Kustomize-based**: Deploy manifests directly
 
 ### Option 1: Operator-Managed Telemetry
 
-When using the ODH/RHOAI operator, telemetry can be enabled via the ModelsAsService CR:
+When using the ODH/RHOAI operator, telemetry can be enabled via the Tenant CR (self-bootstrapped by `maas-controller` in the `models-as-a-service` namespace):
 
 ```yaml
-apiVersion: components.platform.opendatahub.io/v1alpha1
-kind: ModelsAsService
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: Tenant
 metadata:
-  name: default-modelsasservice
+  name: default-tenant
+  namespace: models-as-a-service
 spec:
   telemetry:
     enabled: true  # Enable TelemetryPolicy and Istio Telemetry
@@ -169,11 +170,11 @@ spec:
 Or patch an existing CR:
 
 ```bash
-kubectl patch modelsasservice default-modelsasservice --type=merge \
+kubectl patch tenant default-tenant -n models-as-a-service --type=merge \
   -p '{"spec":{"telemetry":{"enabled":true}}}'
 ```
 
-**What the operator creates when `telemetry.enabled: true`:**
+**What the Tenant reconciler creates when `telemetry.enabled: true`:**
 
 | Resource | Namespace | Purpose |
 |----------|-----------|---------|
@@ -181,13 +182,13 @@ kubectl patch modelsasservice default-modelsasservice --type=merge \
 | Istio Telemetry (`latency-per-subscription`) | Gateway namespace | Adds `subscription` label to gateway latency metrics |
 
 !!! note "Prerequisites for Operator-Managed Telemetry"
-    The operator-managed telemetry feature requires:
+    The Tenant reconciler telemetry feature requires:
 
     - **OpenShift Service Mesh (Istio)** 2.4+ — for Istio Telemetry CRD
     - **Kuadrant/RHCL** — for TelemetryPolicy CRD and AuthPolicy header injection
     - **Gateway deployed** — Telemetry targets the gateway via selector
 
-    The operator checks for CRD availability before creating resources. If a CRD is not present, that resource is silently skipped.
+    The Tenant reconciler checks for CRD availability before creating resources. If a CRD is not present, that resource is silently skipped.
 
 !!! warning "AuthPolicy Header Dependency"
     The Istio Telemetry reads the `subscription` value from the `X-MaaS-Subscription` header, which must be injected by AuthPolicy:

--- a/docs/content/concepts/architecture.md
+++ b/docs/content/concepts/architecture.md
@@ -97,7 +97,7 @@ graph TB
 6. Only the hash and metadata (username, groups, name, `subscription` — the MaaSSubscription name bound at mint, `expiresAt`) are stored in PostgreSQL.
 7. The plaintext key is returned to the user **only in this minting response** (show-once), along with `expiresAt`; it is **not** exposed again on later reads. The diagram below stops at storage and does not show the HTTP response back to the user.
 
-Every key expires. With **operator-managed** MaaS, the cluster operator sets the maximum lifetime on the **`ModelsAsService`** CR: **`spec.apiKeys.maxExpirationDays`** (see [ModelsAsService CR](../install/maas-setup.md#modelsasservice-cr)). **`maas-api`** applies that cap as **`API_KEY_MAX_EXPIRATION_DAYS`** (for example 90 days by default when defaults apply). Omit **`expiresIn`** on create to use that maximum, or set a shorter **`expiresIn`** (e.g., `30d`, `90d`, `1h`) within the configured cap. The response always includes **`expiresAt`** (RFC3339).
+Every key expires. With **operator-managed** MaaS, the cluster operator sets the maximum lifetime on the **`Tenant`** CR: **`spec.apiKeys.maxExpirationDays`** (see [Tenant CR](../install/maas-setup.md#tenant-cr)). **`maas-api`** applies that cap as **`API_KEY_MAX_EXPIRATION_DAYS`** (for example 90 days by default when defaults apply). Omit **`expiresIn`** on create to use that maximum, or set a shorter **`expiresIn`** (e.g., `30d`, `90d`, `1h`) within the configured cap. The response always includes **`expiresAt`** (RFC3339).
 
 ```mermaid
 graph TB

--- a/docs/content/configuration-and-management/maas-controller-overview.md
+++ b/docs/content/configuration-and-management/maas-controller-overview.md
@@ -2,18 +2,18 @@
 
 This document describes the **MaaS Controller**: what was built, how it fits into the Models-as-a-Service (MaaS) stack, and how the pieces work together. It is intended for presentations, onboarding, and technical deep-dives.
 
-!!! todo "Documentation cleanup"
-    TODO: Clean up this documentation.
-
 ---
 
 ## 1. What Is the MaaS Controller?
 
-The **MaaS Controller** is a Kubernetes controller that provides a **subscription-style control plane** for Models-as-a-Service. It lets platform operators define:
+The **MaaS Controller** is a Kubernetes controller with two main responsibilities:
 
-- **Which models** are exposed through MaaS (via **MaaSModelRef**).
-- **Who can access** those models (via **MaaSAuthPolicy**).
-- **Per-user/per-group token rate limits** for those models (via **MaaSSubscription**).
+1. **Tenant reconciler** — deploys and manages the MaaS platform workloads (`maas-api`, gateway policies, telemetry, DestinationRule) via the **`Tenant`** CR (`maas.opendatahub.io/v1alpha1`). On startup the controller self-bootstraps a `default-tenant` CR in the `models-as-a-service` namespace if one does not exist. The Tenant reconciler renders embedded kustomize manifests at runtime and applies them via Server-Side Apply (SSA).
+
+2. **Subscription reconcilers** — let platform operators define:
+    - **Which models** are exposed through MaaS (via **MaaSModelRef**).
+    - **Who can access** those models (via **MaaSAuthPolicy**).
+    - **Per-user/per-group token rate limits** for those models (via **MaaSSubscription**).
 
 The controller does not run inference. It **reconciles** your high-level MaaS CRs into the underlying Gateway API and Kuadrant resources (HTTPRoutes, AuthPolicies, TokenRateLimitPolicies) that enforce routing, authentication, and rate limiting at the gateway.
 
@@ -23,6 +23,10 @@ The controller does not run inference. It **reconciles** your high-level MaaS CR
 
 ```mermaid
 flowchart TB
+    subgraph Platform["Platform lifecycle"]
+        Tenant["Tenant CR\n(default-tenant)"]
+    end
+
     subgraph Operator["Platform operator"]
         MaaSModelRef["MaaSModelRef"]
         MaaSAuthPolicy["MaaSAuthPolicy"]
@@ -30,9 +34,16 @@ flowchart TB
     end
 
     subgraph Controller["maas-controller"]
+        TenantReconciler["Tenant\nReconciler"]
         ModelReconciler["MaaSModelRef\nReconciler"]
         AuthReconciler["MaaSAuthPolicy\nReconciler"]
         SubReconciler["MaaSSubscription\nReconciler"]
+    end
+
+    subgraph PlatformWorkloads["Platform Workloads"]
+        MaaSAPI["maas-api\n(Deployment, Service, HTTPRoute)"]
+        GatewayPolicies["Gateway default policies\n(AuthPolicy, TokenRateLimitPolicy)"]
+        Telemetry["TelemetryPolicy\nIstio Telemetry"]
     end
 
     subgraph GatewayStack["Gateway API + Kuadrant"]
@@ -44,6 +55,11 @@ flowchart TB
     subgraph Backend["Backend"]
         LLMIS["LLMInferenceService\n(KServe)"]
     end
+
+    Tenant --> TenantReconciler
+    TenantReconciler --> MaaSAPI
+    TenantReconciler --> GatewayPolicies
+    TenantReconciler --> Telemetry
 
     MaaSModelRef --> ModelReconciler
     MaaSAuthPolicy --> AuthReconciler
@@ -58,9 +74,63 @@ flowchart TB
     HTTPRoute --> LLMIS
 ```
 
-**Summary:** You declare intent with MaaS CRs; the controller turns that into Gateway/Kuadrant resources that attach to the same HTTPRoute and backend (e.g. KServe LLMInferenceService).
+**Summary:** The controller has two sides: the **Tenant reconciler** deploys and manages the MaaS platform workloads (maas-api, gateway policies, telemetry) from the `Tenant` CR; the **subscription reconcilers** turn MaaS CRs into Gateway/Kuadrant resources that attach to per-model HTTPRoutes and backends (e.g. KServe LLMInferenceService).
 
 The **MaaS API** GET /v1/models endpoint uses MaaSModelRef CRs as its primary source: it reads them cluster-wide (all namespaces), then **validates access** by probing each model’s `/v1/models` endpoint with the client’s **Authorization header** (passed through as-is). Only models that return 2xx or 405 are included. So the catalogue returned to the client is the set of MaaSModelRef objects the controller reconciles, filtered to those the client can actually access. No token exchange is performed; the header is forwarded as-is.
+
+---
+
+## 2.1. Tenant Resource Layout
+
+The `Tenant` CR is namespace-scoped (lives in `models-as-a-service`). It owns resources across three scopes — same-namespace children use standard `ownerReference`, while cluster-scoped and cross-namespace children use **tracking labels** (Kubernetes rejects cross-namespace and namespaced-to-cluster ownerRefs).
+
+```mermaid
+graph TB
+    subgraph "models-as-a-service namespace"
+        Tenant["Tenant CR<br/>default-tenant"]
+        API["maas-api Deployment"]
+        CM["ConfigMaps"]
+        SVC["Services"]
+        SA["ServiceAccounts"]
+        NP["NetworkPolicies"]
+        HR["HTTPRoutes"]
+        AP2["maas-api AuthPolicy"]
+    end
+
+    subgraph "openshift-ingress namespace"
+        AP["gateway AuthPolicy"]
+        DR["DestinationRule"]
+        TP["TelemetryPolicy"]
+        IT["Istio Telemetry"]
+    end
+
+    subgraph "Cluster-scoped"
+        CR["ClusterRoles"]
+        CRB["ClusterRoleBindings"]
+    end
+
+    Tenant -->|ownerRef| API
+    Tenant -->|ownerRef| CM
+    Tenant -->|ownerRef| SVC
+    Tenant -->|ownerRef| SA
+    Tenant -->|ownerRef| NP
+    Tenant -->|ownerRef| HR
+    Tenant -->|ownerRef| AP2
+    Tenant -.->|tracking labels| CR
+    Tenant -.->|tracking labels| CRB
+    Tenant -.->|tracking labels| AP
+    Tenant -.->|tracking labels| DR
+    Tenant -.->|tracking labels| TP
+    Tenant -.->|tracking labels| IT
+
+    style Tenant fill:#4a90d9,color:#fff
+    style AP fill:#f5a623,color:#fff
+    style DR fill:#f5a623,color:#fff
+    style TP fill:#f5a623,color:#fff
+    style IT fill:#f5a623,color:#fff
+```
+
+**Solid arrows** = standard ownerReference (automatic GC). **Dashed arrows** = tracking labels (finalizer-based cleanup). **Orange resources** = cross-namespace children that require tracking labels.
 
 ---
 
@@ -149,19 +219,22 @@ flowchart TB
     subgraph Cluster["Kubernetes cluster"]
         subgraph maas_controller["maas-controller (Deployment)"]
             Manager["Controller Manager"]
+            TenantReconciler["Tenant\nReconciler"]
             ModelReconciler["MaaSModelRef\nReconciler"]
             AuthReconciler["MaaSAuthPolicy\nReconciler"]
             SubReconciler["MaaSSubscription\nReconciler"]
         end
 
-        CRDs["CRDs: MaaSModelRef,\nMaaSAuthPolicy,\nMaaSSubscription"]
+        CRDs["CRDs: Tenant,\nMaaSModelRef,\nMaaSAuthPolicy,\nMaaSSubscription"]
         RBAC["RBAC: ClusterRole,\nServiceAccount, etc."]
     end
 
     Watch["Watch MaaS CRs,\nGateway API, Kuadrant,\nLLMInferenceService"]
+    Manager --> TenantReconciler
     Manager --> ModelReconciler
     Manager --> AuthReconciler
     Manager --> SubReconciler
+    TenantReconciler --> Watch
     ModelReconciler --> Watch
     AuthReconciler --> Watch
     SubReconciler --> Watch
@@ -169,7 +242,7 @@ flowchart TB
     RBAC --> maas_controller
 ```
 
-- Single binary: **manager** runs three reconcilers.
+- Single binary: **manager** runs four reconcilers (Tenant + three subscription reconcilers).
 - Registers **Kubernetes core**, **Gateway API**, **KServe (v1alpha1)**, and **MaaS (v1alpha1)** schemes; uses **unstructured** for Kuadrant resources.
 - Reads/writes MaaS CRs, HTTPRoutes, Gateways, AuthPolicies, TokenRateLimitPolicies, and LLMInferenceServices (read-only for model metadata/routes).
 
@@ -216,7 +289,8 @@ flowchart LR
     Deploy --> Examples
 ```
 
-- **Namespaces**: MaaS API and controller default to **opendatahub** (configurable). MaaSAuthPolicy and MaaSSubscription default to **models-as-a-service** (configurable). MaaSModelRef must live in the **same namespace** as the model it references (e.g. **llm**).
+- **Namespaces**: MaaS API and controller default to **opendatahub** (configurable). The **Tenant** CR, MaaSAuthPolicy and MaaSSubscription default to **models-as-a-service** (configurable). MaaSModelRef must live in the **same namespace** as the model it references (e.g. **llm**).
+- **Self-bootstrap**: On startup, `maas-controller` creates a `default-tenant` CR in the `models-as-a-service` namespace if one does not exist. The Tenant reconciler then deploys `maas-api` and gateway policies via SSA.
 - **Install**: `./scripts/deploy.sh` installs the full stack including the controller. Optionally run `./scripts/install-examples.sh` for sample MaaSModelRef, MaaSAuthPolicy, and MaaSSubscription.
 
 ---
@@ -263,10 +337,10 @@ Model workloads (vLLM, Llama.cpp, etc.) do not require strong identity claims in
 
 | Topic | Summary |
 |-------|---------|
-| **What** | MaaS Controller = control plane that reconciles MaaSModelRef, MaaSAuthPolicy, and MaaSSubscription into Gateway API and Kuadrant resources. |
-| **Where** | Single controller in `opendatahub`; MaaSAuthPolicy / MaaSSubscription default to `models-as-a-service`; MaaSModelRef and generated Kuadrant policies target their model’s namespace. |
-| **How** | Three reconcilers watch MaaS CRs (and related resources); each creates/updates HTTPRoutes, AuthPolicies, or TokenRateLimitPolicies. |
+| **What** | MaaS Controller = control plane with a **Tenant reconciler** (deploys maas-api and gateway policies from a `Tenant` CR) and **subscription reconcilers** (reconcile MaaSModelRef, MaaSAuthPolicy, MaaSSubscription into Gateway API and Kuadrant resources). |
+| **Where** | Single controller in `opendatahub`; `Tenant` CR / MaaSAuthPolicy / MaaSSubscription default to `models-as-a-service`; MaaSModelRef and generated Kuadrant policies target their model’s namespace. |
+| **How** | Four reconcilers: Tenant reconciler deploys platform workloads via SSA; three subscription reconcilers watch MaaS CRs (and related resources) and create/update HTTPRoutes, AuthPolicies, or TokenRateLimitPolicies. |
 | **Identity bridge** | AuthPolicy exposes all user groups as a comma-separated `groups_str`; TokenRateLimitPolicy uses `groups_str.split(",").exists(...)` for subscription matching (the “string trick”). |
-| **Deploy** | Run `./scripts/deploy.sh`; optionally install examples. |
+| **Deploy** | Run `./scripts/deploy.sh`; controller self-bootstraps `default-tenant`; optionally install examples. |
 
 This overview should be enough to explain what was created and how it works in talks or written docs.

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -139,7 +139,7 @@ After creating the database Secret and Gateways, create or update your DataScien
 
 === "Managed (Recommended)"
 
-    The operator deploys and manages the MaaS API. Create or update your DataScienceCluster with `modelsAsService` in Managed state:
+    The operator deploys `maas-controller`, which self-bootstraps a `default-tenant` CR and reconciles the MaaS platform workloads (maas-api, gateway policies, telemetry). Create or update your DataScienceCluster with `modelsAsService` in Managed state:
 
     ```yaml
     kubectl apply -f - <<EOF
@@ -179,23 +179,30 @@ After creating the database Secret and Gateways, create or update your DataScien
     kubectl rollout status deployment/maas-api -n opendatahub --timeout=120s
     ```
 
-    The operator will automatically deploy:
+    The `maas-controller` (deployed by the operator) will automatically create a `default-tenant` CR and reconcile:
 
     - **MaaS API** (Deployment, Service, ServiceAccount, ClusterRole, ClusterRoleBinding, HTTPRoute)
     - **MaaS API AuthPolicy** (maas-api-auth-policy) - Protects the MaaS API endpoint
+    - **Gateway default AuthPolicy** (gateway-default-auth) - Denies unauthenticated traffic
+    - **Gateway default TokenRateLimitPolicy** (gateway-default-deny) - Denies unsubscribed traffic
+    - **TelemetryPolicy and Istio Telemetry** (when telemetry is enabled)
+    - **DestinationRule** (when TLS is enabled)
     - **NetworkPolicy** (maas-authorino-allow) - Allows Authorino to reach MaaS API
 
-    ### ModelsAsService CR
+    ### Tenant CR
 
-    With `modelsAsService` **Managed**, the [Open Data Hub operator](https://github.com/opendatahub-io/opendatahub-operator) reconciles a **cluster-scoped** `ModelsAsService` object. The resource name **must** be `default-modelsasservice` (only one instance per cluster). The authoritative API definition is in the operator repo: [`modelsasservice_types.go`](https://github.com/opendatahub-io/opendatahub-operator/blob/main/api/components/v1alpha1/modelsasservice_types.go).
+    With `modelsAsService` **Managed**, the [Open Data Hub operator](https://github.com/opendatahub-io/opendatahub-operator) deploys `maas-controller`, which self-bootstraps a **namespace-scoped** `Tenant` object on startup. The resource name **must** be `default-tenant` (enforced via CEL validation). The `Tenant` CR lives in the `models-as-a-service` namespace (same namespace as `MaaSSubscription` and `MaaSAuthPolicy`). The authoritative API definition is in the maas-controller repo: [`tenant_types.go`](https://github.com/opendatahub-io/models-as-a-service/blob/main/maas-controller/api/maas/v1alpha1/tenant_types.go).
 
-    **Nothing in `spec` is required for a default install.** If you omit `spec`, the operator uses the same defaults as this guide: Gateway **`openshift-ingress` / `maas-default-gateway`**, and telemetry metric toggles use the defaults described below.
+    **Nothing in `spec` is required for a default install.** If you omit `spec`, the controller uses the same defaults as this guide: Gateway **`openshift-ingress` / `maas-default-gateway`**, and telemetry metric toggles use the defaults described below.
 
     | Field | What to set |
     | ----- | ----------- |
     | `spec.gatewayRef.namespace` | Namespace of your Gateway API `Gateway` (default `openshift-ingress`). |
     | `spec.gatewayRef.name` | Name of that `Gateway` (default `maas-default-gateway`). Set these if your MaaS hostname is exposed through a different Gateway than the default. |
-    | `spec.apiKeys.maxExpirationDays` | Maximum allowed API key lifetime in **days**. When set, users cannot mint keys with a longer lifetime than this value (via `expiresIn`). Optional; if unset, the operator does not apply a cap through this field (see also `maas-api` / `API_KEY_MAX_EXPIRATION_DAYS` in your deployment). |
+    | `spec.apiKeys.maxExpirationDays` | Maximum allowed API key lifetime in **days**. When set, users cannot mint keys with a longer lifetime than this value (via `expiresIn`). Optional; if unset, the controller does not apply a cap through this field (see also `maas-api` / `API_KEY_MAX_EXPIRATION_DAYS` in your deployment). |
+    | `spec.externalOIDC.issuerUrl` | OIDC issuer URL for external identity provider (optional; enables OIDC on the maas-api AuthPolicy). |
+    | `spec.externalOIDC.clientId` | OIDC client ID (required when `issuerUrl` is set). |
+    | `spec.telemetry.enabled` | Enable TelemetryPolicy and Istio Telemetry (default `true`). |
     | `spec.telemetry.metrics.captureOrganization` | Include `organization_id` on metrics (default `true`). |
     | `spec.telemetry.metrics.captureUser` | Include user labels on metrics (default `false`; privacy-sensitive). |
     | `spec.telemetry.metrics.captureGroup` | Include group labels on metrics (default `false`; higher cardinality). |
@@ -204,10 +211,11 @@ After creating the database Secret and Gateways, create or update your DataScien
     Example (patch common values):
 
     ```yaml
-    apiVersion: components.platform.opendatahub.io/v1alpha1
-    kind: ModelsAsService
+    apiVersion: maas.opendatahub.io/v1alpha1
+    kind: Tenant
     metadata:
-      name: default-modelsasservice
+      name: default-tenant
+      namespace: models-as-a-service
     spec:
       gatewayRef:
         namespace: openshift-ingress
@@ -215,14 +223,15 @@ After creating the database Secret and Gateways, create or update your DataScien
       apiKeys:
         maxExpirationDays: 90
       telemetry:
+        enabled: true
         metrics:
           captureUser: false
           captureGroup: false
     ```
 
     ```bash
-    kubectl apply -f modelsasservice.yaml
-    kubectl get modelsasservice default-modelsasservice -o yaml
+    kubectl apply -f tenant.yaml
+    kubectl get tenant default-tenant -n models-as-a-service -o yaml
     ```
 
 === "Kustomize"

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -87,12 +87,13 @@ For OpenShift clusters, use the unified automated deployment script. Choose your
 The deployment script creates the following core resources:
 
 - **Gateway**: `maas-default-gateway` in `openshift-ingress` namespace
-- **HTTPRoutes**: `maas-api-route` in the `redhat-ods-applications` namespace (deployed by operator)
+- **HTTPRoutes**: `maas-api-route` in the application namespace (deployed by Tenant reconciler)
 - **Policies**:
-  - `maas-api-auth-policy` (deployed by operator) - Protects MaaS API
-  - `gateway-auth-policy` (deployed by script) - Protects Gateway/model inference
-  - `TokenRateLimitPolicy`, `RateLimitPolicy` (deployed by script) - Usage limits
-- **MaaS API**: Deployment and service in `redhat-ods-applications` namespace (deployed by operator)
+  - `maas-api-auth-policy` (deployed by Tenant reconciler) - Protects MaaS API
+  - `gateway-default-auth` (deployed by Tenant reconciler) - Denies unauthenticated traffic
+  - `gateway-default-deny` (deployed by Tenant reconciler) - Denies unsubscribed traffic
+- **MaaS API**: Deployment and service in the application namespace (deployed by Tenant reconciler)
+- **Tenant CR**: `default-tenant` in `models-as-a-service` namespace (self-bootstrapped by maas-controller)
 - **Operators**: Cert-manager, LWS, Red Hat Connectivity Link and Red Hat OpenShift AI.
 
 Check deployment status:
@@ -109,16 +110,20 @@ kubectl get authpolicy -A
 kubectl get tokenratelimitpolicy -A
 kubectl get ratelimitpolicy -A
 
-# Check MaaS API (deployed by operator in redhat-ods-applications)
-kubectl get pods -n redhat-ods-applications -l app.kubernetes.io/name=maas-api
-kubectl get svc -n redhat-ods-applications maas-api
+# Check MaaS API (deployed by Tenant reconciler in the application namespace)
+# APP_NS is "opendatahub" for ODH or "redhat-ods-applications" for RHOAI
+kubectl get pods -n ${APP_NS} -l app.kubernetes.io/name=maas-api
+kubectl get svc -n ${APP_NS} maas-api
 
 # Check Kuadrant operators
 kubectl get pods -n kuadrant-system
 
+# Check Tenant CR
+kubectl get tenant default-tenant -n models-as-a-service
+
 # Check RHOAI/KServe
 kubectl get pods -n kserve
-kubectl get pods -n redhat-ods-applications
+kubectl get pods -n ${APP_NS}
 ```
 
 !!! tip "TLS Configuration"

--- a/docs/content/release-notes/index.md
+++ b/docs/content/release-notes/index.md
@@ -8,6 +8,10 @@ Version 3.4.0 introduces new CRDs and API resources that are not compatible with
 
 **Migration:** See the overall migration plan for detailed upgrade instructions from previous versions.
 
+### Tenant CR
+
+The **`Tenant`** CR (`maas.opendatahub.io/v1alpha1`) is the platform configuration object for MaaS. It is self-bootstrapped by `maas-controller` on startup as `default-tenant` in the `models-as-a-service` namespace. Optional `spec` fields (`gatewayRef`, `apiKeys`, `telemetry`, `externalOIDC`) allow customizing gateway, API key lifetime, telemetry, and external OIDC. See [Tenant CR](../install/maas-setup.md#tenant-cr) for details.
+
 ### Known limitations
 
 - **Shared HTTPRoute and token rate limits:** Multiple **MaaSModelRef** resources on the same **HTTPRoute** can yield multiple **TokenRateLimitPolicy** objects, but **only one limit set may be enforced** at the gateway until the controller change in [opendatahub-io/models-as-a-service#585](https://github.com/opendatahub-io/models-as-a-service/pull/585) is in your build. See [Subscription limitations and known issues](../configuration-and-management/subscription-known-issues.md#token-rate-limits-when-multiple-model-references-share-one-httproute).

--- a/docs/samples/models/e2e-distinct-2-simulated/model.yaml
+++ b/docs/samples/models/e2e-distinct-2-simulated/model.yaml
@@ -19,6 +19,7 @@ spec:
       - name: main
         image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
         imagePullPolicy: Always
+        command: ["/app/llm-d-inference-sim"]
         args:
         - --port
         - "8000"

--- a/docs/samples/models/e2e-distinct-simulated/model.yaml
+++ b/docs/samples/models/e2e-distinct-simulated/model.yaml
@@ -19,6 +19,7 @@ spec:
       - name: main
         image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
         imagePullPolicy: Always
+        command: ["/app/llm-d-inference-sim"]
         args:
         - --port
         - "8000"

--- a/docs/samples/models/simulator-premium/model.yaml
+++ b/docs/samples/models/simulator-premium/model.yaml
@@ -19,6 +19,7 @@ spec:
       - name: main
         image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
         imagePullPolicy: Always
+        command: ["/app/llm-d-inference-sim"]
         args:
         - --port
         - "8000"

--- a/docs/samples/models/simulator/model.yaml
+++ b/docs/samples/models/simulator/model.yaml
@@ -22,6 +22,7 @@ spec:
       - name: main
         image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
         imagePullPolicy: Always
+        command: ["/app/llm-d-inference-sim"]
         args:
         - --port
         - "8000"

--- a/maas-api/Dockerfile.konflux
+++ b/maas-api/Dockerfile.konflux
@@ -16,7 +16,7 @@ COPY . .
 USER root
 RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o maas-api ./cmd/
 
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:175bafd5bc7893540ed6234bb979acfe3574fd6570e6762bbc527c757f854cea
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00
 
 WORKDIR /app
 

--- a/maas-api/Dockerfile.konflux
+++ b/maas-api/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG GOLANG_VERSION=1.25
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:77bfb0f283eaa3215909342c3dda940605eff5b9f72d6dc18fad1d154d172d55 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:1e1c89558f8bf86db3d88e5d5de0b6bd396ef948749a2c5d6a752ea46f35d4db AS builder
 ARG CGO_ENABLED=1
 ARG TARGETOS
 ARG TARGETARCH

--- a/maas-api/Dockerfile.konflux
+++ b/maas-api/Dockerfile.konflux
@@ -16,7 +16,7 @@ COPY . .
 USER root
 RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o maas-api ./cmd/
 
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:175bafd5bc7893540ed6234bb979acfe3574fd6570e6762bbc527c757f854cea
 
 WORKDIR /app
 

--- a/maas-api/Dockerfile.konflux
+++ b/maas-api/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG GOLANG_VERSION=1.25
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:1e1c89558f8bf86db3d88e5d5de0b6bd396ef948749a2c5d6a752ea46f35d4db AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder
 ARG CGO_ENABLED=1
 ARG TARGETOS
 ARG TARGETARCH

--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG GOLANG_VERSION=1.25
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:1e1c89558f8bf86db3d88e5d5de0b6bd396ef948749a2c5d6a752ea46f35d4db AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder
 ARG CGO_ENABLED=1
 ARG GOEXPERIMENT=strictfipsruntime
 ARG TARGETOS

--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -17,7 +17,7 @@ COPY maas-controller/ ./
 USER root
 RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
 
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:175bafd5bc7893540ed6234bb979acfe3574fd6570e6762bbc527c757f854cea
 
 WORKDIR /
 

--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -17,7 +17,7 @@ COPY maas-controller/ ./
 USER root
 RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
 
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:175bafd5bc7893540ed6234bb979acfe3574fd6570e6762bbc527c757f854cea
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00
 
 WORKDIR /
 

--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG GOLANG_VERSION=1.25
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:77bfb0f283eaa3215909342c3dda940605eff5b9f72d6dc18fad1d154d172d55 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:1e1c89558f8bf86db3d88e5d5de0b6bd396ef948749a2c5d6a752ea46f35d4db AS builder
 ARG CGO_ENABLED=1
 ARG GOEXPERIMENT=strictfipsruntime
 ARG TARGETOS

--- a/maas-controller/README.md
+++ b/maas-controller/README.md
@@ -20,6 +20,22 @@ The Tenant reconciler watches `Tenant` CRs and deploys `maas-api` into the targe
 
 The `RELATED_IMAGE_ODH_MAAS_API_IMAGE` environment variable controls which `maas-api` image the Tenant reconciler deploys. When set on the controller Deployment, it overrides the default image in the kustomize manifests.
 
+#### Design decisions
+
+**Namespace-scoped CR.** The `Tenant` CR is namespace-scoped (`models-as-a-service`), not cluster-scoped like other ODH component CRDs. CRD `spec.scope` is immutable — changing it after deployment requires deleting all CR instances and the CRD itself (brief MaaS outage, permanent operator migration code). Shipping namespace-scoped from `v1alpha1` avoids that cost entirely and enables future multi-tenancy (one `default-tenant` per namespace).
+
+**Self-bootstrap singleton.** The controller creates `default-tenant` on startup if it does not exist. A CEL validation rule (`self.metadata.name == 'default-tenant'`) enforces exactly one Tenant per namespace. This is consistent with the ODH component lifecycle (DSC enables → operator deploys controller → controller creates CR) while keeping the platform workload lifecycle inside `maas-controller`.
+
+**Cross-namespace ownership.** The Tenant CR lives in the app namespace but five resources are created in the gateway namespace (`openshift-ingress`): `AuthPolicy`, `TokenRateLimitPolicy`, `DestinationRule`, `TelemetryPolicy`, and `Istio Telemetry`. Kubernetes rejects cross-namespace `ownerReference`, so these use tracking labels instead:
+
+```yaml
+labels:
+  maas.opendatahub.io/tenant-name: default-tenant
+  maas.opendatahub.io/tenant-namespace: models-as-a-service
+```
+
+Same-namespace children use standard `ownerReference` (automatic GC). Cluster-scoped and cross-namespace children use tracking labels and are cleaned up by the Tenant finalizer via label queries.
+
 ### Subscription model
 
 The controller implements a **dual-gate** model where both gates must pass for a request to succeed:

--- a/maas-controller/api/maas/v1alpha1/externalmodel_types.go
+++ b/maas-controller/api/maas/v1alpha1/externalmodel_types.go
@@ -42,11 +42,9 @@ type ExternalModel struct {
 // ExternalModelSpec defines the desired state of ExternalModel
 type ExternalModelSpec struct {
 	// Provider identifies the API format and auth type for the external model.
-	// The allowed values are: "openai", "anthropic", "azure-openai", "vertex" and "bedrock-openai".
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Enum=openai;anthropic;azure-openai;vertex;bedrock-openai
 	Provider string `json:"provider"`
 
 	// TargetModel is the upstream model name at the external provider.

--- a/maas-controller/api/maas/v1alpha1/maassubscription_types.go
+++ b/maas-controller/api/maas/v1alpha1/maassubscription_types.go
@@ -74,8 +74,10 @@ type ModelSubscriptionRef struct {
 
 // TokenRateLimit defines a token rate limit
 type TokenRateLimit struct {
-	// Limit is the maximum number of tokens allowed
+	// Limit is the maximum number of tokens allowed within the window.
+	// Must be between 1 and 1,000,000,000 (1 billion).
 	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1000000000
 	Limit int64 `json:"limit"`
 
 	// Window is the time window for rate limiting (e.g., "1m", "1h", "24h").

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -472,6 +472,7 @@ func main() {
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
 		MaaSAPINamespace: maasAPINamespace,
+		TenantNamespace:  maasSubscriptionNamespace,
 		GatewayName:      gatewayName,
 		ClusterAudience:  clusterAudience,
 		MetadataCacheTTL: metadataCacheTTL,

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -54,6 +54,10 @@ type MaaSAuthPolicyReconciler struct {
 	// Used to construct the subscription selector endpoint URL.
 	MaaSAPINamespace string
 
+	// TenantNamespace is the namespace where the Tenant CR lives (configurable via flags).
+	// Defaults to "models-as-a-service".
+	TenantNamespace string
+
 	// GatewayName is the name of the Gateway used for model HTTPRoutes (configurable via flags).
 	GatewayName string
 
@@ -68,6 +72,12 @@ type MaaSAuthPolicyReconciler struct {
 	// AuthzCacheTTL is the TTL in seconds for Authorino OPA authorization caching.
 	// Applies to auth-valid, subscription-valid, and require-group-membership authorization evaluators.
 	AuthzCacheTTL int64
+}
+
+// oidcConfig holds OIDC configuration from Tenant CR
+type oidcConfig struct {
+	IssuerURL string
+	ClientID  string
 }
 
 func (r *MaaSAuthPolicyReconciler) clusterAudience() string {
@@ -99,12 +109,114 @@ func (r *MaaSAuthPolicyReconciler) authzCacheTTL() int64 {
 	return metadata
 }
 
+// fetchOIDCConfig fetches OIDC configuration from the Tenant CR.
+// Returns nil if Tenant CR doesn't exist or doesn't have externalOIDC configured.
+func (r *MaaSAuthPolicyReconciler) fetchOIDCConfig(ctx context.Context, log logr.Logger) *oidcConfig {
+	// Tenant is a namespace-scoped singleton resource named "default-tenant"
+	// GVK: maas.opendatahub.io/v1alpha1, Kind: Tenant
+	tenant := &unstructured.Unstructured{}
+	tenant.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "maas.opendatahub.io",
+		Version: "v1alpha1",
+		Kind:    "Tenant",
+	})
+
+	// Get the singleton Tenant CR (name enforced by CRD validation)
+	tenantKey := client.ObjectKey{
+		Name:      maasv1alpha1.TenantInstanceName,
+		Namespace: r.TenantNamespace,
+	}
+
+	if err := r.Get(ctx, tenantKey, tenant); err != nil {
+		if apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			log.V(1).Info("Tenant CRD not installed or Tenant not found, OIDC support disabled",
+				"tenantName", maasv1alpha1.TenantInstanceName,
+				"tenantNamespace", r.TenantNamespace)
+			return nil
+		}
+		log.Error(err, "failed to get Tenant resource",
+			"tenantName", maasv1alpha1.TenantInstanceName,
+			"tenantNamespace", r.TenantNamespace)
+		return nil
+	}
+
+	// Extract spec.externalOIDC if present
+	oidcSpec, found, err := unstructured.NestedMap(tenant.Object, "spec", "externalOIDC")
+	if err != nil {
+		log.Error(err, "failed to extract spec.externalOIDC from Tenant")
+		return nil
+	}
+	if !found || oidcSpec == nil {
+		log.V(1).Info("Tenant CR has no externalOIDC configuration")
+		return nil
+	}
+
+	// Extract issuerUrl and clientId
+	issuerURL, _, err := unstructured.NestedString(oidcSpec, "issuerUrl")
+	if err != nil {
+		log.Error(err, "Tenant externalOIDC.issuerUrl has invalid type (expected string)",
+			"oidcSpec", oidcSpec)
+		return nil
+	}
+
+	clientID, _, err := unstructured.NestedString(oidcSpec, "clientId")
+	if err != nil {
+		log.Error(err, "Tenant externalOIDC.clientId has invalid type (expected string)",
+			"oidcSpec", oidcSpec)
+		return nil
+	}
+
+	if issuerURL == "" {
+		log.V(1).Info("Tenant externalOIDC has no issuerUrl")
+		return nil
+	}
+
+	if clientID == "" {
+		log.Error(nil, "Tenant externalOIDC has no clientId - audience validation is required for security")
+		return nil
+	}
+
+	log.Info("OIDC configuration loaded from Tenant CR",
+		"issuerUrl", issuerURL,
+		"clientId", clientID)
+
+	return &oidcConfig{
+		IssuerURL: issuerURL,
+		ClientID:  clientID,
+	}
+}
+
 // CEL sub-expressions reused across Authorino cache-key selectors.
+// These handle API keys, OIDC tokens, and Kubernetes tokens.
 const (
+	// celUserID extracts user ID from API key, OIDC, or K8s token
+	// Used for cache keys (UUID for API keys, username for others)
+	// API key: uses apiKeyValidation.userId (database UUID)
+	// OIDC: uses preferred_username or sub (from JWT claims)
+	// K8s: uses user.username (from TokenReview)
 	celUserID = `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ` +
-		`? auth.metadata.apiKeyValidation.userId : auth.identity.user.username`
+		`? auth.metadata.apiKeyValidation.userId ` +
+		`: (has(auth.identity.preferred_username) ? auth.identity.preferred_username ` +
+		`: (has(auth.identity.sub) ? auth.identity.sub : auth.identity.user.username))`
+
+	// celUsername extracts username for subscription ownership checks
+	// Unlike celUserID (which uses UUID for API key cache keys), this always uses the actual username
+	// API key: uses apiKeyValidation.username (service account name)
+	// OIDC: uses preferred_username or sub (from JWT claims)
+	// K8s: uses user.username (from TokenReview)
+	celUsername = `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ` +
+		`? auth.metadata.apiKeyValidation.username ` +
+		`: (has(auth.identity.preferred_username) ? auth.identity.preferred_username ` +
+		`: (has(auth.identity.sub) ? auth.identity.sub : auth.identity.user.username))`
+
+	// celGroups extracts groups from API key, OIDC, or K8s token
+	// API key: uses apiKeyValidation.groups (snapshot at key creation)
+	// OIDC: uses groups claim (no .user. prefix)
+	// K8s: uses user.groups (from TokenReview)
 	celGroups = `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ` +
-		`? auth.metadata.apiKeyValidation.groups : auth.identity.user.groups`
+		`? auth.metadata.apiKeyValidation.groups ` +
+		`: (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)`
+
 	celSubscription = `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ` +
 		`? auth.metadata.apiKeyValidation.subscription : ` +
 		`("x-maas-subscription" in request.headers ? request.headers["x-maas-subscription"] : "")`
@@ -135,12 +247,17 @@ func authzCacheKeySelector(ns, name string) string {
 //+kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get
+//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop
 const maasAuthPolicyFinalizer = "maas.opendatahub.io/authpolicy-cleanup"
 
 func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx).WithValues("MaaSAuthPolicy", req.NamespacedName)
+
+	// Fetch OIDC configuration from Tenant CR (if present)
+	// This is checked on every reconcile to handle dynamic updates to the CR
+	oidcConfig := r.fetchOIDCConfig(ctx, log)
 
 	policy := &maasv1alpha1.MaaSAuthPolicy{}
 	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
@@ -168,7 +285,8 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Track missing models to include in status even when reconciliation skips them
 	missingModels := r.findMissingModelRefs(ctx, policy)
 
-	refs, err := r.reconcileModelAuthPolicies(ctx, log, policy)
+	refs, err := r.reconcileModelAuthPolicies(ctx, log, policy, oidcConfig)
+
 	if err != nil {
 		log.Error(err, "failed to reconcile model AuthPolicies")
 		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to reconcile: %v", err), statusSnapshot)
@@ -248,7 +366,7 @@ type authPolicyRef struct {
 	ModelNamespace string
 }
 
-func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Context, log logr.Logger, policy *maasv1alpha1.MaaSAuthPolicy) ([]authPolicyRef, error) {
+func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Context, log logr.Logger, policy *maasv1alpha1.MaaSAuthPolicy, oidcConfig *oidcConfig) ([]authPolicyRef, error) {
 	var refs []authPolicyRef
 	// Model-centric approach: for each model referenced by this auth policy,
 	// find ALL auth policies for that model and build a single aggregated AuthPolicy.
@@ -360,11 +478,11 @@ func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Contex
 						"method":      "POST",
 						"body": map[string]any{
 							"expression": fmt.Sprintf(`{
-  "groups": (has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.groups : auth.identity.user.groups,
-  "username": (has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.username : auth.identity.user.username,
+  "groups": %s,
+  "username": %s,
   "requestedSubscription": `+celSubscription+`,
   "requestedModel": "%s/%s"
-}`, ref.Namespace, ref.Name),
+}`, celGroups, celUsername, ref.Namespace, ref.Name),
 						},
 					},
 					// Cache subscription selection results keyed by user ID, groups, requested subscription, and model.
@@ -427,12 +545,46 @@ func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Contex
 			},
 		}
 
+		// Add OIDC authentication if configured in Tenant CR
+		if oidcConfig != nil && oidcConfig.IssuerURL != "" {
+			authenticationRules, ok := rule["authentication"].(map[string]any)
+			if !ok {
+				return nil, errors.New("failed to convert authentication rules to map[string]any")
+			}
+
+			// Build JWT config with issuer URL and audience (both required)
+			// The JWT's aud claim must match the OIDC client ID for security
+			jwtConfig := map[string]any{
+				"issuerUrl": oidcConfig.IssuerURL,
+				"audiences": []any{oidcConfig.ClientID},
+			}
+
+			authenticationRules["oidc-identities"] = map[string]any{
+				"jwt": jwtConfig,
+				"when": []any{
+					// Only for /v1/models endpoint
+					map[string]any{
+						"selector": "request.url_path",
+						"operator": "matches",
+						"value":    ".*/v1/models$",
+					},
+					// JWT pattern match (exclude API keys)
+					map[string]any{
+						"predicate": `!request.headers.authorization.startsWith("Bearer sk-oai-") && request.headers.authorization.matches("^Bearer [^.]+\\.[^.]+\\.[^.]+$")`,
+					},
+				},
+				"metrics":  false,
+				"priority": int64(2), // After kubernetes-tokens (priority 1)
+			}
+		}
+
 		// Build authorization rules
 		authRules := make(map[string]any)
 
-		// Validate authentication: API key must be valid, OR K8s token must be authenticated
+		// Validate authentication: API key must be valid, OR K8s token must be authenticated, OR OIDC token must be authenticated
 		// For API keys: check apiKeyValidation.valid == true (boolean)
 		// For K8s tokens: check that identity.username exists (TokenReview succeeded)
+		// For OIDC tokens: check that identity.sub exists (JWT validated)
 		authRules["auth-valid"] = map[string]any{
 			"metrics":  false,
 			"priority": int64(0),
@@ -446,16 +598,27 @@ allow {
 # Kubernetes token authentication: check identity exists
 allow {
   object.get(input.auth.identity, "user", {}).username != ""
+}
+
+# OIDC token authentication: check JWT subject exists
+allow {
+  object.get(input.auth.identity, "sub", "") != ""
 }`,
 			},
 			// Cache authorization result keyed by authentication source and identity.
 			// For API keys: uses the API key value
+			// For OIDC tokens: uses the JWT subject (sub claim)
 			// For K8s tokens: uses the username
 			// Key format: "auth-type|identity|model"
 			// TTL cannot exceed metadata TTL (auth-valid depends on apiKeyValidation metadata)
 			"cache": map[string]any{
 				"key": map[string]any{
-					"selector": fmt.Sprintf(`(has(auth.metadata.apiKeyValidation) ? "api-key|" + request.headers.authorization.replace("Bearer ", "") : "k8s-token|" + auth.identity.user.username) + "|%s/%s"`, ref.Namespace, ref.Name),
+					"selector": fmt.Sprintf(
+						`(has(auth.metadata.apiKeyValidation) ? "api-key|" + `+
+							`request.headers.authorization.replace("Bearer ", "") : `+
+							`(has(auth.identity.sub) ? "oidc|" + auth.identity.sub : `+
+							`"k8s-token|" + auth.identity.user.username)) + "|%s/%s"`,
+						ref.Namespace, ref.Name),
 				},
 				"ttl": r.authzCacheTTL(),
 			},
@@ -513,16 +676,22 @@ allow {
 allowed_groups := %s
 allowed_users := %s
 
-# Extract username from API key or K8s token
+# Extract username from API key, OIDC, or K8s token
 username := input.auth.metadata.apiKeyValidation.username
     { object.get(input.auth, "metadata", {}).apiKeyValidation.username != "" }
+else := input.auth.identity.preferred_username
+    { object.get(input.auth, "identity", {}).preferred_username != "" }
+else := input.auth.identity.sub
+    { object.get(input.auth, "identity", {}).sub != "" }
 else := input.auth.identity.user.username
     { object.get(input.auth, "identity", {}).user.username != "" }
 else := ""
 
-# Extract groups from API key or K8s token
+# Extract groups from API key, OIDC, or K8s token
 groups := input.auth.metadata.apiKeyValidation.groups
     { object.get(input.auth, "metadata", {}).apiKeyValidation.groups != [] }
+else := input.auth.identity.groups
+    { object.get(input.auth, "identity", {}).groups != [] }
 else := input.auth.identity.user.groups
     { object.get(input.auth, "identity", {}).user.groups != [] }
 else := []
@@ -995,6 +1164,14 @@ func (r *MaaSAuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	generatedAuthPolicy := &unstructured.Unstructured{}
 	generatedAuthPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
 
+	// Watch Tenant so we re-reconcile when OIDC configuration changes.
+	tenant := &unstructured.Unstructured{}
+	tenant.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "maas.opendatahub.io",
+		Version: "v1alpha1",
+		Kind:    "Tenant",
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&maasv1alpha1.MaaSAuthPolicy{}, builder.WithPredicates(predicate.Or(
 			predicate.GenerationChangedPredicate{},
@@ -1013,7 +1190,34 @@ func (r *MaaSAuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(generatedAuthPolicy, handler.EnqueueRequestsFromMapFunc(
 			r.mapGeneratedAuthPolicyToParent,
 		)).
+		// Watch Tenant so OIDC configuration changes trigger reconciles.
+		Watches(tenant, handler.EnqueueRequestsFromMapFunc(
+			r.mapTenantToMaaSAuthPolicies,
+		)).
 		Complete(r)
+}
+
+// mapTenantToMaaSAuthPolicies enqueues all MaaSAuthPolicy resources
+// when Tenant changes (to pick up OIDC configuration changes).
+func (r *MaaSAuthPolicyReconciler) mapTenantToMaaSAuthPolicies(ctx context.Context, obj client.Object) []reconcile.Request {
+	// List all MaaSAuthPolicy resources
+	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
+	if err := r.List(ctx, policyList); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list MaaSAuthPolicy resources for Tenant change")
+		return nil
+	}
+
+	// Enqueue reconcile requests for all policies
+	requests := make([]reconcile.Request, len(policyList.Items))
+	for i, policy := range policyList.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      policy.Name,
+				Namespace: policy.Namespace,
+			},
+		}
+	}
+	return requests
 }
 
 // mapGeneratedAuthPolicyToParent maps a generated AuthPolicy back to any

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestFetchOIDCConfig_NoTenant(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := &MaaSAuthPolicyReconciler{
+		Client:          client,
+		Scheme:          scheme,
+		TenantNamespace: "models-as-a-service",
+	}
+
+	config := reconciler.fetchOIDCConfig(context.Background(), logr.Discard())
+	assert.Nil(t, config, "should return nil when Tenant doesn't exist")
+}
+
+func TestFetchOIDCConfig_NoExternalOIDC(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	// Create Tenant without externalOIDC
+	tenant := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "maas.opendatahub.io/v1alpha1",
+			"kind":       "Tenant",
+			"metadata": map[string]any{
+				"name":      "default-tenant",
+				"namespace": "models-as-a-service",
+			},
+			"spec": map[string]any{
+				"otherField": "value",
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tenant).
+		Build()
+
+	reconciler := &MaaSAuthPolicyReconciler{
+		Client:          client,
+		Scheme:          scheme,
+		TenantNamespace: "models-as-a-service",
+	}
+
+	config := reconciler.fetchOIDCConfig(context.Background(), logr.Discard())
+	assert.Nil(t, config, "should return nil when externalOIDC is not configured")
+}
+
+func TestFetchOIDCConfig_WithExternalOIDC(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	// Create Tenant with externalOIDC
+	tenant := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "maas.opendatahub.io/v1alpha1",
+			"kind":       "Tenant",
+			"metadata": map[string]any{
+				"name":      "default-tenant",
+				"namespace": "models-as-a-service",
+			},
+			"spec": map[string]any{
+				"externalOIDC": map[string]any{
+					"issuerUrl": "https://keycloak.example.com/realms/test",
+					"clientId":  "test-client",
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tenant).
+		Build()
+
+	reconciler := &MaaSAuthPolicyReconciler{
+		Client:          client,
+		Scheme:          scheme,
+		TenantNamespace: "models-as-a-service",
+	}
+
+	config := reconciler.fetchOIDCConfig(context.Background(), logr.Discard())
+	assert.NotNil(t, config, "should return config when externalOIDC is configured")
+	assert.Equal(t, "https://keycloak.example.com/realms/test", config.IssuerURL)
+	assert.Equal(t, "test-client", config.ClientID)
+}
+
+func TestFetchOIDCConfig_EmptyIssuerURL(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	// Create Tenant with empty issuerUrl
+	tenant := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "maas.opendatahub.io/v1alpha1",
+			"kind":       "Tenant",
+			"metadata": map[string]any{
+				"name":      "default-tenant",
+				"namespace": "models-as-a-service",
+			},
+			"spec": map[string]any{
+				"externalOIDC": map[string]any{
+					"issuerUrl": "",
+					"clientId":  "test-client",
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tenant).
+		Build()
+
+	reconciler := &MaaSAuthPolicyReconciler{
+		Client:          client,
+		Scheme:          scheme,
+		TenantNamespace: "models-as-a-service",
+	}
+
+	config := reconciler.fetchOIDCConfig(context.Background(), logr.Discard())
+	assert.Nil(t, config, "should return nil when issuerUrl is empty")
+}
+
+func TestFetchOIDCConfig_EmptyClientID(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	// Create Tenant with empty clientId
+	tenant := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "maas.opendatahub.io/v1alpha1",
+			"kind":       "Tenant",
+			"metadata": map[string]any{
+				"name":      "default-tenant",
+				"namespace": "models-as-a-service",
+			},
+			"spec": map[string]any{
+				"externalOIDC": map[string]any{
+					"issuerUrl": "https://keycloak.example.com/realms/test",
+					"clientId":  "",
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tenant).
+		Build()
+
+	reconciler := &MaaSAuthPolicyReconciler{
+		Client:          client,
+		Scheme:          scheme,
+		TenantNamespace: "models-as-a-service",
+	}
+
+	config := reconciler.fetchOIDCConfig(context.Background(), logr.Discard())
+	assert.Nil(t, config, "should return nil when clientId is empty (audience validation required)")
+}
+
+func TestCELExpressions_SupportOIDC(t *testing.T) {
+	// Test that CEL expressions include OIDC identity fields
+	assert.Contains(t, celUserID, "auth.identity.preferred_username",
+		"celUserID should check for OIDC preferred_username")
+	assert.Contains(t, celUserID, "auth.identity.sub",
+		"celUserID should check for OIDC sub claim")
+	assert.Contains(t, celUserID, "auth.identity.user.username",
+		"celUserID should fall back to K8s user.username")
+
+	assert.Contains(t, celUsername, "auth.identity.preferred_username",
+		"celUsername should check for OIDC preferred_username")
+	assert.Contains(t, celUsername, "auth.identity.sub",
+		"celUsername should check for OIDC sub claim")
+	assert.Contains(t, celUsername, "auth.identity.user.username",
+		"celUsername should fall back to K8s user.username")
+
+	assert.Contains(t, celGroups, "auth.identity.groups",
+		"celGroups should check for OIDC groups claim")
+	assert.Contains(t, celGroups, "auth.identity.user.groups",
+		"celGroups should fall back to K8s user.groups")
+}
+
+func TestCELExpressions_UserIDVsUsername(t *testing.T) {
+	// Test that celUserID uses userId (UUID for cache keys)
+	assert.Contains(t, celUserID, "auth.metadata.apiKeyValidation.userId",
+		"celUserID should use userId for API key cache keys (UUID)")
+
+	// Test that celUsername uses username (service account name for authz)
+	assert.Contains(t, celUsername, "auth.metadata.apiKeyValidation.username",
+		"celUsername should use username for API key authorization (service account name)")
+
+	// Verify celUserID does NOT use .username (it should use .userId)
+	assert.NotContains(t, celUserID, "apiKeyValidation.username",
+		"celUserID should NOT use username field")
+
+	// Verify celUsername does NOT use .userId (it should use .username)
+	assert.NotContains(t, celUsername, "apiKeyValidation.userId",
+		"celUsername should NOT use userId field")
+}
+
+func TestCELExpressions_OrderMatters(t *testing.T) {
+	// Verify that OIDC checks come before K8s checks
+	// This is important because OIDC and K8s identity structures differ
+
+	// For username: should check preferred_username before user.username
+	preferredIdx := findSubstring(celUserID, "preferred_username")
+	userUsernameIdx := findSubstring(celUserID, "user.username")
+	assert.True(t, preferredIdx >= 0, "should check for preferred_username")
+	assert.True(t, userUsernameIdx >= 0, "should check for user.username")
+	assert.True(t, preferredIdx < userUsernameIdx,
+		"should check preferred_username (OIDC) before user.username (K8s)")
+
+	// For groups: should check auth.identity.groups before auth.identity.user.groups
+	identityGroupsIdx := findSubstring(celGroups, "auth.identity.groups")
+	userGroupsIdx := findSubstring(celGroups, "auth.identity.user.groups")
+	assert.True(t, identityGroupsIdx >= 0, "should check for auth.identity.groups")
+	assert.True(t, userGroupsIdx >= 0, "should check for auth.identity.user.groups")
+	assert.True(t, identityGroupsIdx < userGroupsIdx,
+		"should check auth.identity.groups (OIDC) before auth.identity.user.groups (K8s)")
+}
+
+// Helper function to find substring index
+func findSubstring(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -84,7 +84,6 @@ func (r *MaaSModelRefReconciler) gatewayNamespace() string {
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get
 
 const maasModelFinalizer = "maas.opendatahub.io/model-cleanup"
 

--- a/maas-controller/pkg/controller/maas/maassubscription_controller.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -66,7 +68,58 @@ const (
 	// modelRefIndexKey is the field index key for looking up MaaSSubscriptions by model reference.
 	// The index value format is "namespace/name" of the model.
 	modelRefIndexKey = "spec.modelRef"
+
+	// maxTokenRateLimit caps the token limit to prevent Kuadrant validation failures.
+	// Values above this are unreasonable for any practical rate-limiting scenario.
+	maxTokenRateLimit int64 = 1_000_000_000 // 1 billion tokens
+
+	// maxWindowSeconds caps the window duration to 366 days (one leap year) to prevent
+	// unreasonably large windows from reaching Kuadrant. 8784h fits the CRD pattern
+	// ^[1-9]\d{0,3}(s|m|h)$.
+	maxWindowSeconds int64 = 366 * 24 * 3600 // 366 days (leap year) in seconds
 )
+
+var windowPattern = regexp.MustCompile(`^[1-9]\d{0,3}(s|m|h)$`)
+
+// validateTokenRateLimit checks if a token rate limit has reasonable values that
+// Kuadrant will accept. Returns an error describing the issue if invalid.
+func validateTokenRateLimit(limit int64, window string) error {
+	if limit <= 0 {
+		return fmt.Errorf("token limit %d must be positive", limit)
+	}
+	if limit > maxTokenRateLimit {
+		return fmt.Errorf("token limit %d exceeds maximum allowed value %d", limit, maxTokenRateLimit)
+	}
+
+	matches := windowPattern.FindStringSubmatch(window)
+	if len(matches) != 2 {
+		return fmt.Errorf("invalid window format %q: expected a positive number followed by s, m, or h (e.g. \"1h\", \"30m\")", window)
+	}
+
+	// Extract numeric part (everything except the last character).
+	unit := matches[1]
+	numStr := window[:len(window)-len(unit)]
+	value, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid window numeric value %q: %w", numStr, err)
+	}
+
+	var seconds int64
+	switch unit {
+	case "s":
+		seconds = value
+	case "m":
+		seconds = value * 60
+	case "h":
+		seconds = value * 3600
+	}
+
+	if seconds > maxWindowSeconds {
+		return fmt.Errorf("window %q (%d seconds) exceeds maximum allowed duration (%d seconds)", window, seconds, maxWindowSeconds)
+	}
+
+	return nil
+}
 
 // ConditionSpecPriorityDuplicate is set True when another MaaSSubscription shares the same spec.priority
 // (API key mint and selector use deterministic tie-break; admins should set distinct priorities).
@@ -459,16 +512,39 @@ func (r *MaaSSubscriptionReconciler) reconcileTRLPForModel(ctx context.Context, 
 				continue
 			}
 			var rates []any
+			var hasInvalidLimits bool
 			if len(mRef.TokenRateLimits) > 0 {
 				for _, trl := range mRef.TokenRateLimits {
+					if err := validateTokenRateLimit(trl.Limit, trl.Window); err != nil {
+						log.Error(err, "Skipping subscription with invalid token rate limit — fix the spec to include it in TRLP",
+							"subscription", sub.Name, "model", modelNamespace+"/"+modelName,
+							"limit", trl.Limit, "window", trl.Window)
+						hasInvalidLimits = true
+						break
+					}
 					rates = append(rates, map[string]any{"limit": trl.Limit, "window": trl.Window})
 				}
 			} else {
 				rates = append(rates, map[string]any{"limit": int64(100), "window": "1m"})
 			}
+			if hasInvalidLimits {
+				// Skip this subscription to prevent poisoning the aggregated TRLP.
+				// The subscription is already marked Degraded/Failed by validateModelRefs(),
+				// and maas-api's subscription selector rejects non-Active subscriptions,
+				// so the invalid subscription cannot be used for API key minting.
+				continue
+			}
 			subs = append(subs, subInfo{sub: sub, mRef: mRef, rates: rates})
 			break
 		}
+	}
+
+	// If all subscriptions were skipped due to invalid limits, treat as no effective
+	// subscriptions — delete the TRLP instead of writing one with empty limits.
+	if len(subs) == 0 && len(allSubs) > 0 {
+		log.Info("All subscriptions for model have invalid rate limits — deleting TRLP",
+			"model", modelNamespace+"/"+modelName, "invalidCount", len(allSubs))
+		return r.deleteModelTRLP(ctx, log, modelNamespace, modelName)
 	}
 
 	// Trust auth.identity.selected_subscription_key from AuthPolicy.

--- a/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
@@ -1248,7 +1248,7 @@ func TestMaaSSubscriptionReconciler_WindowValuesInTRLP(t *testing.T) {
 		{"seconds", "30s"},      // short window, typical for burst limits
 		{"minutes", "5m"},       // default-like value used across the codebase
 		{"hours", "24h"},        // common replacement for the now-removed "1d"
-		{"max digits", "9999h"}, // upper bound of the 4-digit numeric cap
+		{"max digits", "8784h"}, // upper bound: 366 days (leap year) in hours
 	}
 
 	for _, tc := range tests {

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -57,7 +57,8 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants/finalizers,verbs=update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,resourceNames=maas-db-config,verbs=get
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;delete

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,7 +37,7 @@ Automated deployment script for OpenShift clusters supporting both operator-base
 - `--operator-type <odh|rhoai>` - Which operator to install (default: odh)
 - `--deployment-mode <operator|kustomize>` - Deployment method (default: operator)
 - `--namespace <namespace>` - Target namespace for deployment
-- `--external-oidc` - Enable external OIDC on the `maas-api` AuthPolicy (kustomize mode only; in operator mode, configure `spec.externalOIDC` on the `ModelsAsService` CR)
+- `--external-oidc` - Enable external OIDC on the `maas-api` AuthPolicy (kustomize mode only; in operator mode, configure `spec.externalOIDC` on the `Tenant` CR)
 - `--enable-keycloak` - Deploy a Keycloak instance for external OIDC testing
 - `--enable-tls-backend` - Enable TLS backend (default)
 - `--disable-tls-backend` - Disable TLS backend
@@ -155,8 +155,8 @@ Results:
 
 External OIDC can be enabled in two ways:
 
-**Operator mode:** Edit the `ModelsAsService` CR to add `spec.externalOIDC` with
-`issuerUrl` and `clientId`. The operator patches the AuthPolicy automatically.
+**Operator mode:** Edit the `Tenant` CR to add `spec.externalOIDC` with
+`issuerUrl` and `clientId`. The Tenant reconciler patches the AuthPolicy automatically.
 
 **Kustomize mode:** Use `--external-oidc` with env vars:
 ```bash

--- a/test/e2e/fixtures/trlp-test/llm/llmis.yaml
+++ b/test/e2e/fixtures/trlp-test/llm/llmis.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     containers:
       - name: main
-        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
         imagePullPolicy: Always
         command: ["/app/llm-d-inference-sim"]
         args:
@@ -27,6 +27,7 @@ spec:
         - test/e2e-trlp-test-model
         - --mode
         - random
+        - --no-mm-encoder-only
         - --ssl-certfile
         - /var/run/kserve/tls/tls.crt
         - --ssl-keyfile
@@ -42,6 +43,11 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
         ports:
           - name: https
             containerPort: 8000

--- a/test/e2e/scripts/auth_utils.sh
+++ b/test/e2e/scripts/auth_utils.sh
@@ -16,6 +16,7 @@
 #     maasauthpolicies.yaml      - MaaSAuthPolicy definitions
 #     maassubscriptions.yaml     - MaaSSubscription definitions
 #     externalmodels.yaml        - ExternalModel definitions
+#     tenants.yaml               - Tenant definitions
 #   pod-logs/                  - Per-pod logs from the deployment namespace
 #
 # Usage:
@@ -127,6 +128,7 @@ MAAS_CRDS=(
   "maasauthpolicies.maas.opendatahub.io"
   "maassubscriptions.maas.opendatahub.io"
   "externalmodels.maas.opendatahub.io"
+  "tenants.maas.opendatahub.io"
 )
 
 collect_maas_crs() {
@@ -208,6 +210,7 @@ collect_cluster_state() {
     echo "--- MaaS CRs ---"
     kubectl get maasmodelrefs -n "$DEPLOYMENT_NAMESPACE" 2>/dev/null || true
     kubectl get maasauthpolicies,maassubscriptions -n "$MAAS_SUBSCRIPTION_NAMESPACE" 2>/dev/null || true
+    kubectl get tenants -n "$MAAS_SUBSCRIPTION_NAMESPACE" 2>/dev/null || true
     echo ""
     echo "--- HTTPRoutes ---"
     kubectl get httproutes -A 2>/dev/null | head -30 || true
@@ -324,6 +327,8 @@ run_auth_debug_report() {
   _run "MaaSSubscriptions" "kubectl get maassubscriptions -n $MAAS_SUBSCRIPTION_NAMESPACE -o wide 2>/dev/null || true"
   _run "MaaSSubscription status details" "kubectl get maassubscriptions -n $MAAS_SUBSCRIPTION_NAMESPACE -o jsonpath='{range .items[*]}{.metadata.name}: {.status.phase} - {.status.conditions[?(@.type==\"Ready\")].message}{\"\\n\"}{end}' 2>/dev/null || true"
   _run "MaaSModelRefs (all namespaces)" "kubectl get maasmodelrefs -A -o wide 2>/dev/null || true"
+  _run "Tenants" "kubectl get tenants -n $MAAS_SUBSCRIPTION_NAMESPACE -o wide 2>/dev/null || true"
+  _run "Tenant status details" "kubectl get tenants -n $MAAS_SUBSCRIPTION_NAMESPACE -o jsonpath='{range .items[*]}{.metadata.name}: {.status.conditions[?(@.type==\"Ready\")].status} - {.status.conditions[?(@.type==\"Ready\")].message}{\"\\n\"}{end}' 2>/dev/null || true"
   _append ""
 
   _section "Test User Information"

--- a/test/e2e/tests/test_external_oidc.py
+++ b/test/e2e/tests/test_external_oidc.py
@@ -78,6 +78,41 @@ class TestExternalOIDC:
         )
         assert response.status_code == 401, f"Expected 401 for invalid OIDC token, got {response.status_code}: {response.text}"
 
+    def test_oidc_token_can_list_models(self, maas_api_base_url: str):
+        """Test that OIDC token (not minted API key) can list models via /v1/models.
+
+        This tests the OIDC support on model AuthPolicies, not just maas-api AuthPolicy.
+        When OIDC is enabled on model AuthPolicies, users can discover available models
+        without first minting an API key.
+        """
+        token = _request_oidc_token()
+        headers = {"Authorization": f"Bearer {token}"}
+
+        models_response = requests.get(
+            f"{maas_api_base_url}/v1/models",
+            headers=headers,
+            timeout=45,
+            verify=TLS_VERIFY,
+        )
+        assert models_response.status_code == 200, (
+            f"OIDC token failed to list models: {models_response.status_code} {models_response.text}"
+        )
+
+        response_json = models_response.json()
+        assert response_json.get("object") == "list", f"Expected object=list, got: {response_json}"
+
+        items = response_json.get("data", [])
+        # Note: May be empty if OIDC user has no group access to any subscriptions
+        # We only assert the request succeeds (200), not that models are returned
+        print(f"[oidc] OIDC token listed {len(items)} model(s) from /v1/models")
+
+        # If models are returned, verify they have subscription information
+        if items:
+            first_model = items[0]
+            assert "id" in first_model, "Model should have id field"
+            assert "subscriptions" in first_model, "Model should have subscriptions array"
+            print(f"[oidc] First model: {first_model['id']} with {len(first_model.get('subscriptions', []))} subscription(s)")
+
     def test_minted_api_key_can_list_models_and_infer(self, maas_api_base_url: str):
         token = _request_oidc_token()
         api_key = _create_oidc_api_key(maas_api_base_url, token)["key"]
@@ -112,3 +147,67 @@ class TestExternalOIDC:
         )
 
         print(f"[oidc] inference succeeded for {model_id} at {time.time()}")
+
+    def test_oidc_user_without_group_access_gets_empty_list(self, maas_api_base_url: str):
+        """Test that OIDC user with no group access to any subscriptions gets empty list.
+
+        This validates that group-based access control works correctly for OIDC tokens.
+        A user without group membership in any subscription should get 200 OK with an
+        empty model list (not 401 or 403).
+
+        Note: This test requires a user configured in the OIDC provider that has no
+        group memberships matching any subscription groups. If all OIDC users have
+        access (e.g., via system:authenticated), this test will be skipped.
+        """
+        # This test requires environment configuration for a user without group access
+        # Skip if not configured
+        username_no_access = os.environ.get("OIDC_USERNAME_NO_ACCESS", "")
+        password_no_access = os.environ.get("OIDC_PASSWORD_NO_ACCESS", "")
+
+        if not username_no_access or not password_no_access:
+            pytest.skip("OIDC_USERNAME_NO_ACCESS and OIDC_PASSWORD_NO_ACCESS not configured")
+
+        # Get token for user without group access
+        token_url = _required_env("OIDC_TOKEN_URL")
+        client_id = _required_env("OIDC_CLIENT_ID")
+
+        response = requests.post(
+            token_url,
+            data={
+                "grant_type": "password",
+                "client_id": client_id,
+                "username": username_no_access,
+                "password": password_no_access,
+            },
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert response.status_code == 200, f"OIDC token request failed: {response.status_code} {response.text}"
+
+        token = response.json().get("access_token")
+        assert token, "OIDC token response missing access_token"
+
+        # Request models with token from user with no group access
+        models_response = requests.get(
+            f"{maas_api_base_url}/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=45,
+            verify=TLS_VERIFY,
+        )
+
+        # Should get 200 OK, not 401/403
+        assert models_response.status_code == 200, (
+            f"Expected 200 for user without access, got {models_response.status_code}: {models_response.text}"
+        )
+
+        response_json = models_response.json()
+        assert response_json.get("object") == "list", f"Expected object=list, got: {response_json}"
+
+        items = response_json.get("data", [])
+        # Should return empty list (not null)
+        assert isinstance(items, list), f"Expected data to be a list, got {type(items)}"
+        assert len(items) == 0, (
+            f"Expected empty list for user without group access, got {len(items)} model(s)"
+        )
+
+        print("[oidc] User without group access correctly received empty list (200 OK)")


### PR DESCRIPTION
## Summary
Sync `rhoai-3.4` branch with the latest changes from `main` to keep the release branch up to date.

## Description
This PR merges `main` into `rhoai-3.4`, bringing in 17 commits. Merge completed cleanly with no conflicts.

33 files changed across controller code, CRDs, RBAC, dashboards, docs, e2e tests, and Dockerfiles.

### Commits included

| Commit | Description | Upstream PR |
|--------|-------------|-------------|
| cfc8964 | chore(deps): update ubi9/ubi-minimal docker digest to 7d4e475 | [#384](https://github.com/red-hat-data-services/models-as-a-service/pull/384) |
| cbcbd25 | Merge remote-tracking branch 'upstream/rhoai' | — |
| fad486e | chore: promote stable to rhoai | [#789](https://github.com/opendatahub-io/models-as-a-service/pull/789) |
| fb75981 | chore: promote main to stable | [#788](https://github.com/opendatahub-io/models-as-a-service/pull/788) |
| fb2ea25 | feat: add tenant CRD to e2e artifact collection and debug report | [#787](https://github.com/opendatahub-io/models-as-a-service/pull/787) |
| 1b8f212 | chore: restrict rbac for db secret | [#779](https://github.com/opendatahub-io/models-as-a-service/pull/779) |
| e746008 | docs: add/update documentation for Maas Tenant | [#773](https://github.com/opendatahub-io/models-as-a-service/pull/773) |
| b9a8979 | chore(deps): update ubi9/go-toolset docker digest to d637b9d | [#371](https://github.com/red-hat-data-services/models-as-a-service/pull/371) |
| 147eaa2 | fix: per-model(s) top-level values in usage dashboard | [#772](https://github.com/opendatahub-io/models-as-a-service/pull/772) |
| 5928f54 | chore(deps): update ubi9/ubi-minimal docker digest to 175bafd | [#361](https://github.com/red-hat-data-services/models-as-a-service/pull/361) |
| 6bea2fb | chore(deps): update ubi9/go-toolset docker digest to 1e1c895 | [#360](https://github.com/red-hat-data-services/models-as-a-service/pull/360) |
| b327b34 | feat: add OIDC token support for model discovery via /v1/models | [#703](https://github.com/opendatahub-io/models-as-a-service/pull/703) |
| dbf6d03 | fix: validate token rate limits and skip invalid subs in TRLP aggregation | [#752](https://github.com/opendatahub-io/models-as-a-service/pull/752) |
| 89fba29 | chore: promote main to stable | [#770](https://github.com/opendatahub-io/models-as-a-service/pull/770) |
| fae753e | chore: add .worktrees/ to .gitignore | [#774](https://github.com/opendatahub-io/models-as-a-service/pull/774) |
| c01dc5b | fix: minor updates for external model | [#771](https://github.com/opendatahub-io/models-as-a-service/pull/771) |
| 65ca551 | fix: add explicit command to v0.8.2 simulator models | [#765](https://github.com/opendatahub-io/models-as-a-service/pull/765) |

## How It Was Tested
- Clean merge with no conflicts verified locally.
- Existing CI checks will validate the merged content.