### PR TITLE
chore: sync rhoai-3.4 with main

### DIFF
--- a/.tekton/odh-maas-api-pull-request.yaml
+++ b/.tekton/odh-maas-api-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     - io.openshift.tags=odh-maas-api
   - name: output-image
     value: quay.io/rhoai/pull-request-pipelines:odh-maas-api-{{revision}}
+  - name: rhoai-version
+    value: "3.4.0"
   - name: dockerfile
     value: maas-api/Dockerfile.konflux
   - name: path-context

--- a/deployment/components/shared-patches/kustomization.yaml
+++ b/deployment/components/shared-patches/kustomization.yaml
@@ -100,6 +100,21 @@ replacements:
     fieldPaths:
     - spec.template.spec.containers.[name=manager].image
 
+# Replace API key cleanup CronJob image from params.env (ubi-minimal for curl).
+# Enables the operator to override the image with a pinned SHA digest for
+# disconnected environments via RELATED_IMAGE_UBI_MINIMAL_IMAGE.
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.maas-api-key-cleanup-image
+  targets:
+  - select:
+      kind: CronJob
+      name: maas-api-key-cleanup
+    fieldPaths:
+    - spec.jobTemplate.spec.template.spec.containers.[name=cleanup].image
+
 # -----------------------------------------------------------------------------
 # 2. GATEWAY CONFIGURATION
 # -----------------------------------------------------------------------------

--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.0
 	github.com/kserve/kserve v0.0.0-20251121160314-57d83d202f36
 	github.com/lib/pq v1.10.9
 	github.com/openai/openai-go/v2 v2.3.1

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -205,8 +205,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
+github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -40,9 +40,10 @@ const (
 
 // ImageParamKeys maps params.env keys to RELATED_IMAGE_* env vars (same as ODH modelsasservice_support.go).
 var ImageParamKeys = map[string]string{
-	"maas-api-image":           "RELATED_IMAGE_ODH_MAAS_API_IMAGE",
-	"maas-controller-image":    "RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE",
-	"payload-processing-image": "RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE",
+	"maas-api-image":             "RELATED_IMAGE_ODH_MAAS_API_IMAGE",
+	"maas-controller-image":      "RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE",
+	"payload-processing-image":   "RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE",
+	"maas-api-key-cleanup-image": "RELATED_IMAGE_UBI_MINIMAL_IMAGE",
 }
 
 // GVKs used for post-render and readiness (mirrors opendatahub-operator/pkg/cluster/gvk selections for modelsasservice).

--- a/test/e2e/scripts/LOCAL-DEPLOY.md
+++ b/test/e2e/scripts/LOCAL-DEPLOY.md
@@ -1,0 +1,359 @@
+# MaaS Local Deployment Guide
+
+One-click local deployment of the full MaaS + BBR platform on Kind (macOS + Linux/WSL2).
+
+## Quick Start
+
+```bash
+# Deploy everything (~8-10 minutes on first run, ~5 minutes with cached images)
+./test/e2e/scripts/local-deploy.sh
+
+# Rebuild a single component after code changes (~30 seconds)
+./test/e2e/scripts/local-deploy.sh --rebuild bbr
+./test/e2e/scripts/local-deploy.sh --rebuild maas-api
+./test/e2e/scripts/local-deploy.sh --rebuild maas-controller
+./test/e2e/scripts/local-deploy.sh --rebuild all
+
+# Validate everything works (18 checks: pods, inference, auth, TLS)
+./test/e2e/scripts/local-deploy.sh --validate
+
+# Run E2E management tests (API key CRUD, expiration, revocation, etc.)
+./test/e2e/scripts/local-test.sh
+
+# Interactive demo (walks through the stack step by step)
+./test/e2e/scripts/local-demo.sh
+
+# Check status
+./test/e2e/scripts/local-deploy.sh --status
+
+# Teardown
+./test/e2e/scripts/local-deploy.sh --teardown
+```
+
+## Prerequisites
+
+- **macOS** (Apple Silicon or Intel)
+- **Docker Desktop** (6+ CPUs, 8+ GB RAM recommended)
+- **Tools**: `kind`, `kubectl`, `kustomize`, `helm`, `jq` (install via `brew install`)
+- `istioctl` is installed automatically if missing
+
+No other repos need to be cloned. The script auto-clones what it needs.
+
+> **How BBR works**: The BBR (payload-processing) **deployment manifests** (Deployment, Service,
+> EnvoyFilter) live inside this repo at `deployment/base/payload-processing/`. This is the same
+> as OpenShift — the MaaS kustomize overlay includes BBR. On Apple Silicon, the pre-built quay.io
+> image is x86-only, so the script **auto-clones** `ai-gateway-payload-processing` to
+> `../ai-gateway-payload-processing` and builds an arm64 image locally. On x86, the pre-built
+> image is used directly.
+
+## What Gets Deployed
+
+30 pods across 8 namespaces. Full stack matching the OpenShift deployment:
+
+```
+Kind cluster (maas-local)
++-- istio-system (3 pods)
+|   +-- istiod                          # Istio control plane
+|   +-- maas-default-gateway-istio      # Gateway (MetalLB assigns LB IP)
+|   +-- payload-processing              # BBR ext-proc (body-based routing)
+|
++-- kuadrant-system (6 pods)
+|   +-- kuadrant-operator               # Manages auth/rate-limit policies
+|   +-- authorino                       # Auth service (API key + K8s token validation)
+|   +-- limitador                       # Rate limiting
+|   +-- authorino-operator, limitador-operator, dns-operator
+|
++-- maas-system (3 pods)
+|   +-- maas-api                        # REST API (HTTPS 8443, cert-manager TLS)
+|   +-- maas-controller                 # Reconciles MaaS CRDs -> Kuadrant policies
+|   +-- postgres                        # PostgreSQL 16 (ephemeral, API key storage)
+|
++-- kserve (3 pods)
+|   +-- kserve-controller-manager       # KServe (opendatahub fork)
+|   +-- llmisvc-controller-manager      # LLMInferenceService controller
+|   +-- kserve-localmodel-controller    # Local model cache controller
+|
++-- cert-manager (3 pods)               # TLS certificate management
++-- metallb-system (2 pods)             # LoadBalancer for Kind
++-- kube-system (7 pods)                # Kubernetes core
+|
++-- llm (0 pods, networking only)       # External model namespace
+|   +-- ExternalModel: llm-katan-openai # -> 3-13-21-181.sslip.io (AWS, Let's Encrypt TLS)
+|   +-- ServiceEntry + DestinationRule  # Created by controller
+|   +-- HTTPRoute + AuthPolicy          # Created by controller
+|
++-- llm-internal (1 pod)                # Internal model namespace
+|   +-- LLMInferenceService: sim-internal  # llm-d inference simulator
+|   +-- HTTPRoute + AuthPolicy          # Created by controller
+|
++-- models-as-a-service (0 pods)        # Subscription namespace
+    +-- MaaSSubscription                # Token rate limits
+    +-- MaaSAuthPolicy                  # Group-based access control
+```
+
+## How It Matches OpenShift
+
+| Aspect | OpenShift | Kind (this script) |
+|--------|-----------|-------------------|
+| Gateway namespace | openshift-ingress | istio-system |
+| GatewayClass | openshift-default | istio |
+| Kuadrant | OLM operator | Helm chart |
+| KServe | ODH operator + DataScienceCluster | Vanilla KServe + opendatahub fork images |
+| MaaS deploy mode | `deploy.sh --deployment-mode kustomize` (odh overlay) | Custom kustomize overlay (TLS backend) |
+| maas-api TLS | OpenShift service-ca auto-cert | cert-manager CA chain |
+| Authorino CA trust | service-ca bundle in system trust store | Init container injects CA into SSL_CERT_FILE |
+| PostgreSQL | registry.redhat.io/rhel9/postgresql-16 | postgres:16-alpine |
+| LoadBalancer | Cloud provider / OpenShift router | MetalLB |
+| BBR EnvoyFilter | INSERT_AFTER openshift-ingress.kuadrant-... | INSERT_AFTER istio-system.kuadrant-... |
+| External model TLS | Real provider certs (trusted) | Let's Encrypt via sslip.io (trusted) |
+
+## Request Flow
+
+Identical to OpenShift — same filters, same order, same auth chain.
+The only difference is infrastructure (Kind vs OpenShift, MetalLB vs cloud LB).
+
+```
+Client
+  |
+  v
+Gateway (port 80)                                    # identical to OpenShift
+  |
+  +-- Kuadrant Wasm filter (auth check)              # identical to OpenShift
+  |     |
+  |     +-- API key? -> Authorino -> maas-api:8443   # identical to OpenShift
+  |     +-- K8s token? -> Authorino -> TokenReview   # identical to OpenShift
+  |
+  +-- BBR ext-proc (payload-processing)              # identical to OpenShift
+  |     |
+  |     +-- Extract model name from request body
+  |     +-- Resolve ExternalModel -> set X-Gateway-Model-Name header
+  |     +-- Inject provider credentials
+  |     +-- Translate API format (anthropic/bedrock/vertex -> openai)
+  |
+  +-- Route to backend (via HTTPRoute header match)  # identical to OpenShift
+        |
+        +-- External model: ServiceEntry -> llm-katan (AWS, HTTPS 443)
+        +-- Internal model: KServe pod (in-cluster, HTTP 8000)
+```
+
+## Validating the Deployment
+
+### Check all pods are running
+
+```bash
+kubectl get pods -A | grep -v Completed
+```
+
+### Check MaaS resources
+
+```bash
+# Models
+kubectl get externalmodels -A
+kubectl get llminferenceservices -A
+kubectl get maasmodelrefs -A
+
+# Auth & rate limiting
+kubectl get authpolicies -A
+kubectl get maassubscriptions -A
+kubectl get maasauthpolicies -A
+
+# Networking
+kubectl get httproutes -A
+kubectl get serviceentries -A
+kubectl get destinationrules -A
+kubectl get gateway -n istio-system
+```
+
+### Test inference
+
+```bash
+# Port-forward the gateway
+kubectl port-forward -n istio-system svc/maas-default-gateway-istio 8080:80 &
+
+# Create an API key (via kubectl exec, bypassing gateway auth)
+API_KEY=$(kubectl exec -n maas-system deployment/maas-api -- curl -sk \
+  "https://localhost:8443/v1/api-keys" \
+  -H "X-MaaS-Username: test-user" \
+  -H 'X-MaaS-Group: ["system:authenticated"]' \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-test-key"}' | jq -r '.key')
+
+# List models
+curl -s http://localhost:8080/v1/models -H "Authorization: Bearer $API_KEY" | jq .
+
+# External model (llm-katan on AWS)
+curl -s http://localhost:8080/llm/llm-katan-openai/v1/chat/completions \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"llm-katan-echo","messages":[{"role":"user","content":"Hello!"}],"max_tokens":20}' | jq .
+
+# Internal model (llm-d simulator)
+curl -s http://localhost:8080/llm-internal/sim-internal/v1/chat/completions \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Hello!"}],"max_tokens":20}' | jq .
+
+# Verify auth rejection
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/v1/models  # 401
+```
+
+### Run E2E management tests
+
+```bash
+./test/e2e/scripts/local-test.sh
+```
+
+## Troubleshooting
+
+### Logs
+
+```bash
+# MaaS API
+kubectl logs -n maas-system deployment/maas-api -f
+
+# MaaS controller
+kubectl logs -n maas-system deployment/maas-controller -f
+
+# Authorino (auth decisions)
+kubectl logs -n kuadrant-system deployment/authorino -f
+
+# BBR (payload processing)
+kubectl logs -n istio-system deployment/payload-processing -f
+
+# Gateway proxy (Envoy access logs)
+kubectl logs -n istio-system deployment/maas-default-gateway-istio -f
+```
+
+### Common issues
+
+**Auth returns 403 (API key valid but rejected)**:
+Check Authorino logs — usually means Authorino can't reach maas-api:8443.
+Verify the CA trust: `kubectl get configmap maas-ca-bundle -n kuadrant-system`.
+
+**External model returns 503 (TLS error)**:
+Check the DestinationRule: `kubectl get dr -n llm -o yaml`.
+The llm-katan endpoint uses Let's Encrypt via sslip.io — the cert should be trusted.
+
+**Controller keeps restarting**:
+The Tenant PR added a watch on `Authentication.config.openshift.io` which doesn't exist
+on Kind. The controller logs `no matches for kind "Authentication"` errors but still works
+(it retries every 10s). This is expected on non-OpenShift clusters.
+
+**Internal model stays Pending**:
+The llm-d simulator pod may take a minute to start. Check:
+`kubectl get pods -n llm-internal`.
+
+### Inspecting CRDs (equivalent of OpenShift console)
+
+```bash
+# Use kubectl get/describe instead of the OpenShift dashboard
+
+# All MaaS custom resources
+kubectl get externalmodels,maasmodelrefs,maassubscriptions,maasauthpolicies -A
+
+# Detailed view of a resource
+kubectl describe externalmodel llm-katan-openai -n llm
+kubectl describe maassubscription simulator-subscription -n models-as-a-service
+
+# API keys (stored in PostgreSQL, query via maas-api)
+kubectl exec -n maas-system deployment/maas-api -- curl -sk \
+  "https://localhost:8443/v1/api-keys/search" -X POST \
+  -H "X-MaaS-Username: test-user" \
+  -H 'X-MaaS-Group: ["system:authenticated"]' \
+  -H "Content-Type: application/json" -d '{}' | jq .
+
+# Kuadrant policies (generated by MaaS controller)
+kubectl get authpolicies -A -o wide
+kubectl describe authpolicy maas-auth-llm-katan-openai -n llm
+
+# Istio networking (generated by ExternalModel controller)
+kubectl get serviceentries,destinationrules -A
+kubectl describe serviceentry llm-katan-openai -n llm
+```
+
+### Docker / Kind commands
+
+```bash
+# List Kind clusters
+kind get clusters
+
+# Access Kind node
+docker exec -it maas-local-control-plane bash
+
+# Check images loaded in Kind
+docker exec maas-local-control-plane crictl images | grep maas
+
+# Kind cluster resource usage
+docker stats maas-local-control-plane --no-stream
+```
+
+## Development Workflow
+
+### Iterating on code changes
+
+After the initial deploy, use `--rebuild` to quickly test code changes without
+redeploying the full infrastructure:
+
+```bash
+# Example: you changed BBR plugin code
+cd ../ai-gateway-payload-processing
+# ... edit code ...
+cd ../models-as-a-service
+./test/e2e/scripts/local-deploy.sh --rebuild bbr    # ~30 seconds
+
+# Example: you changed maas-api handler
+# ... edit maas-api code ...
+./test/e2e/scripts/local-deploy.sh --rebuild maas-api
+
+# Example: you changed maas-controller reconciler
+# ... edit maas-controller code ...
+./test/e2e/scripts/local-deploy.sh --rebuild maas-controller
+
+# Rebuild everything after pulling latest from all repos
+./test/e2e/scripts/local-deploy.sh --rebuild all    # ~90 seconds
+```
+
+`--rebuild` only rebuilds the Docker image, loads it into Kind, and restarts the
+deployment. The cluster, Istio, Kuadrant, and all CRDs stay untouched.
+
+### When to use --rebuild vs full redeploy
+
+| Scenario | Command |
+|----------|---------|
+| Changed Go/Python code in a component | `--rebuild <component>` |
+| Changed CRD definitions or kustomize manifests | Full redeploy (teardown + deploy) |
+| Changed Kuadrant/Istio/KServe configuration | Full redeploy |
+| Cluster is in a weird state | `--teardown` then deploy |
+
+## Resource Consumption
+
+| Component | CPU request | Memory |
+|-----------|------------|--------|
+| Istio (istiod + gateway) | ~500m | ~1Gi |
+| Kuadrant stack (6 pods) | ~450m | ~1Gi |
+| cert-manager (3 pods) | ~100m | ~256Mi |
+| MaaS (api + controller) | ~60m | ~640Mi |
+| PostgreSQL | ~100m | ~512Mi |
+| KServe (3 pods) | ~100m | ~384Mi |
+| BBR (payload-processing) | ~100m | ~128Mi |
+| llm-d simulator | ~100m | ~256Mi |
+| **Total** | **~1.5 CPU** | **~4Gi** |
+
+Recommended Docker Desktop settings: **6 CPUs, 8GB RAM, 10GB free disk**.
+
+## Deployment Timing (Apple Silicon, cached images)
+
+| Phase | Time |
+|-------|------|
+| Kind cluster creation | ~20s |
+| Istio + MetalLB | ~30s |
+| cert-manager + TLS certs | ~30s |
+| Kuadrant (Helm + Authorino CA) | ~60s |
+| PostgreSQL | ~15s |
+| CRDs (MaaS + KServe) | ~15s |
+| KServe + LLMIS controller | ~90s |
+| Gateway + networking | ~15s |
+| MaaS kustomize build + deploy | ~30s (+ ~120s for arm64 image builds on first run) |
+| Test fixtures + reconciliation | ~30s |
+| **Total (cached)** | **~5-6 minutes** |
+| **Total (first run, arm64 builds)** | **~8-10 minutes** |

--- a/test/e2e/scripts/local-demo.sh
+++ b/test/e2e/scripts/local-demo.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Demo script for MaaS local deployment.
+# Run after ./local-deploy.sh completes.
+
+set -euo pipefail
+
+BOLD='\033[1m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; BLUE='\033[0;34m'
+CYAN='\033[0;36m'; NC='\033[0m'
+
+pause() {
+  echo ""
+  echo -e "  ${YELLOW}[press enter]${NC}"
+  read -r
+}
+
+GATEWAY_NS="istio-system"
+
+# ─── Setup ─────────────────────────────────────────────────────────────────
+
+echo -e "${BOLD}${BLUE}MaaS Local Deployment Demo${NC}"
+echo ""
+
+# Ensure cluster is running
+if ! kubectl cluster-info --context kind-maas-local &>/dev/null; then
+  echo "Error: Kind cluster 'maas-local' not running. Run ./local-deploy.sh first."
+  exit 1
+fi
+kubectl config use-context kind-maas-local &>/dev/null
+
+# Port-forward
+pkill -f "port-forward.*19090" 2>/dev/null || true
+sleep 1
+kubectl port-forward -n "$GATEWAY_NS" svc/maas-default-gateway-istio 19090:80 > /dev/null 2>&1 &
+sleep 2
+
+# Create API key
+API_KEY=$(kubectl exec -n maas-system deployment/maas-api -- curl -sk \
+  "https://localhost:8443/v1/api-keys" \
+  -H "X-MaaS-Username: demo-user" \
+  -H 'X-MaaS-Group: ["system:authenticated"]' \
+  -H "Content-Type: application/json" \
+  -d '{"name":"demo-key"}' 2>/dev/null | jq -r '.key')
+
+# ─── Act 1: What's running ────────────────────────────────────────────────
+
+echo -e "${BOLD}${CYAN}1. What's running${NC}"
+echo ""
+echo -e "  30 pods, 8 namespaces — full MaaS + BBR + Kuadrant + KServe stack"
+echo ""
+
+for ns in istio-system kuadrant-system maas-system kserve; do
+  count=$(kubectl get pods -n $ns --no-headers 2>/dev/null | grep Running | wc -l | tr -d ' ')
+  echo -e "  ${GREEN}$ns${NC}: $count pods"
+done
+
+echo ""
+echo -e "  ${GREEN}Gateway${NC}: $(kubectl get gateway -n $GATEWAY_NS -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) (Programmed)"
+echo -e "  ${GREEN}Models${NC}:  $(kubectl get maasmodelrefs -A --no-headers 2>/dev/null | wc -l | tr -d ' ') registered"
+
+pause
+
+# ─── Act 2: Auth works ─────────────────────────────────────────────────────
+
+echo -e "${BOLD}${CYAN}2. Auth is enforced (Kuadrant + Authorino)${NC}"
+echo ""
+
+echo -e "  ${BOLD}No API key:${NC}"
+echo -e "  $ curl http://gateway/v1/models"
+HTTP=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:19090/v1/models)
+echo -e "  ${YELLOW}→ HTTP $HTTP Unauthorized${NC}"
+echo ""
+
+echo -e "  ${BOLD}Invalid API key:${NC}"
+echo -e "  $ curl -H 'Authorization: Bearer sk-oai-FAKE' http://gateway/v1/models"
+HTTP=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:19090/v1/models -H "Authorization: Bearer sk-oai-FAKE")
+echo -e "  ${YELLOW}→ HTTP $HTTP Forbidden${NC}"
+echo ""
+
+echo -e "  ${BOLD}Valid API key:${NC}"
+echo -e "  $ curl -H 'Authorization: Bearer sk-oai-...' http://gateway/v1/models"
+MODELS=$(curl -s http://localhost:19090/v1/models -H "Authorization: Bearer $API_KEY" | jq -c '[.data[].id]')
+echo -e "  ${GREEN}→ HTTP 200 — $MODELS${NC}"
+
+pause
+
+# ─── Act 3: External model inference ───────────────────────────────────────
+
+echo -e "${BOLD}${CYAN}3. External model inference (llm-katan on AWS, Let's Encrypt TLS)${NC}"
+echo ""
+echo -e "  Request → Gateway → Kuadrant auth → BBR (model resolve + credential inject) → llm-katan"
+echo ""
+echo -e "  $ curl http://gateway/llm/llm-katan-openai/v1/chat/completions"
+
+RESP=$(curl -s --max-time 15 http://localhost:19090/llm/llm-katan-openai/v1/chat/completions \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"llm-katan-echo","messages":[{"role":"user","content":"Hello from local MaaS!"}],"max_tokens":30}')
+
+echo -e "  ${GREEN}→ $(echo "$RESP" | jq -r '.choices[0].message.content')${NC}"
+echo ""
+echo -e "  Model: $(echo "$RESP" | jq -r '.model')  |  Tokens: $(echo "$RESP" | jq -r '.usage.total_tokens')"
+echo ""
+echo -e "  TLS: Let's Encrypt cert, verified by Istio (no insecureSkipVerify)"
+echo -e "  DestinationRule: $(kubectl get dr llm-katan-openai -n llm -o jsonpath='{.spec.trafficPolicy.tls.mode}' 2>/dev/null) (no insecureSkipVerify)"
+
+pause
+
+# ─── Act 4: Internal model inference ──────────────────────────────────────
+
+echo -e "${BOLD}${CYAN}4. Internal model inference (llm-d simulator, in-cluster via KServe)${NC}"
+echo ""
+echo -e "  Request → Gateway → Kuadrant auth → KServe HTTPRoute → llm-d pod"
+echo ""
+echo -e "  $ curl http://gateway/llm-internal/sim-internal/v1/chat/completions"
+
+RESP=$(curl -s --max-time 15 http://localhost:19090/llm-internal/sim-internal/v1/chat/completions \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Tell me something"}],"max_tokens":20}')
+
+echo -e "  ${GREEN}→ $(echo "$RESP" | jq -r '.choices[0].message.content')${NC}"
+echo ""
+echo -e "  Model: $(echo "$RESP" | jq -r '.model')  |  Tokens: $(echo "$RESP" | jq -r '.usage.total_tokens')"
+
+pause
+
+# ─── Act 5: Fast rebuild ──────────────────────────────────────────────────
+
+echo -e "${BOLD}${CYAN}5. Fast iteration: --rebuild${NC}"
+echo ""
+echo -e "  After a code change in any component:"
+echo ""
+echo -e "  $ ./local-deploy.sh --rebuild bbr             # ~15 seconds"
+echo -e "  $ ./local-deploy.sh --rebuild maas-api         # ~15 seconds"
+echo -e "  $ ./local-deploy.sh --rebuild maas-controller  # ~15 seconds"
+echo -e "  $ ./local-deploy.sh --rebuild all              # ~45 seconds"
+echo ""
+echo -e "  Rebuilds the image, loads into Kind, restarts the deployment."
+echo -e "  Cluster infrastructure stays untouched."
+
+pause
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+
+echo -e "${BOLD}${CYAN}Summary${NC}"
+echo ""
+echo "  One script deploys the full MaaS platform locally:"
+echo "    - MaaS API + Controller (TLS backend, matching OpenShift)"
+echo "    - BBR (payload-processing, ext-proc body routing)"
+echo "    - Kuadrant (auth + rate limiting)"
+echo "    - KServe (LLMInferenceService for internal models)"
+echo "    - PostgreSQL, Istio, cert-manager, MetalLB"
+echo ""
+echo "  External model: llm-katan on AWS with Let's Encrypt TLS"
+echo "  Internal model: llm-d simulator via KServe"
+echo "  Auth: API key validation through full Authorino → maas-api chain"
+echo ""
+echo "  Zero existing files modified. Zero manual configuration."
+echo ""
+
+# Cleanup
+pkill -f "port-forward.*19090" 2>/dev/null || true

--- a/test/e2e/scripts/local-deploy.sh
+++ b/test/e2e/scripts/local-deploy.sh
@@ -1,0 +1,1548 @@
+#!/bin/bash
+# Deploy MaaS platform locally on a Kind cluster (macOS + Linux/WSL2).
+#
+# One-click deployment of: Kind + Istio + Gateway API + cert-manager +
+# Kuadrant (auth/rate-limiting) + PostgreSQL + MaaS controller + MaaS API.
+#
+# Usage:
+#   ./test/e2e/scripts/local-deploy.sh            # Deploy everything
+#   ./test/e2e/scripts/local-deploy.sh --teardown  # Delete the Kind cluster
+#   ./test/e2e/scripts/local-deploy.sh --status    # Show component status
+#
+# Environment variables:
+#   KIND_CLUSTER_NAME    - Cluster name (default: maas-local)
+#   ISTIO_VERSION        - Istio version (default: 1.29.2)
+#   KUADRANT_VERSION     - Kuadrant Helm chart version (default: 1.3.1)
+#   MAAS_NAMESPACE       - MaaS deployment namespace (default: maas-system)
+#   GATEWAY_NAMESPACE    - Gateway namespace (default: istio-system)
+
+set -euo pipefail
+
+# ─── Constants ──────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-maas-local}"
+ISTIO_VERSION="${ISTIO_VERSION:-1.29.2}"  # needs Envoy >=1.37 for ext_proc FULL_DUPLEX fix (envoy#41654)
+KUADRANT_VERSION="${KUADRANT_VERSION:-1.3.1}"  # matches MaaS install-dependencies.sh
+CERTMANAGER_VERSION="${CERTMANAGER_VERSION:-1.17.2}"
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-1.3.0}"
+MAAS_NAMESPACE="${MAAS_NAMESPACE:-maas-system}"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-istio-system}"
+SUBSCRIPTION_NAMESPACE="models-as-a-service"
+
+MAAS_API_IMAGE="${MAAS_API_IMAGE:-quay.io/opendatahub/maas-api:latest}"
+MAAS_CONTROLLER_IMAGE="${MAAS_CONTROLLER_IMAGE:-quay.io/opendatahub/maas-controller:latest}"
+BBR_IMAGE="${BBR_IMAGE:-quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable}"
+
+# Path to BBR repo (for arm64 image builds)
+BBR_REPO="${BBR_REPO:-$(cd "$PROJECT_ROOT/../ai-gateway-payload-processing" 2>/dev/null && pwd || echo "")}"
+
+# KServe (for LLMInferenceService / internal models)
+KSERVE_VERSION="${KSERVE_VERSION:-v0.15.2}"
+KSERVE_COMMIT="47894470ea49"  # opendatahub fork commit pinned in maas-controller go.mod
+KSERVE_ODH_IMAGE="quay.io/opendatahub/kserve-controller:latest"
+LLMISVC_IMAGE="quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-stable"
+
+ARCH="$(uname -m)"
+# Docker platform string (arm64 stays arm64, x86_64 becomes amd64)
+DOCKER_PLATFORM="linux/$(if [[ "$ARCH" == "x86_64" ]]; then echo amd64; else echo "$ARCH"; fi)"
+
+# Source deployment helpers for create_maas_db_config_secret
+# shellcheck source=../../../scripts/deployment-helpers.sh
+source "$PROJECT_ROOT/scripts/deployment-helpers.sh"
+
+# ─── Colors ─────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+step_num=0
+step() {
+  step_num=$((step_num + 1))
+  echo ""
+  echo -e "${BOLD}${BLUE}[$step_num] $1${NC}"
+  echo "────────────────────────────────────────"
+}
+
+ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
+warn() { echo -e "  ${YELLOW}!${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1" >&2; }
+
+# ─── Argument parsing ───────────────────────────────────────────────────────
+
+ACTION="deploy"
+REBUILD_COMPONENT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --teardown)  ACTION="teardown" ;;
+    --status)    ACTION="status" ;;
+    --validate)  ACTION="validate" ;;
+    --rebuild)
+      ACTION="rebuild"
+      REBUILD_COMPONENT="${2:-}"
+      if [[ -z "$REBUILD_COMPONENT" ]] || [[ "$REBUILD_COMPONENT" == --* ]]; then
+        echo "Usage: $0 --rebuild <bbr|maas-api|maas-controller>"
+        exit 1
+      fi
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--teardown | --status | --validate | --rebuild <component> | --help]"
+      echo ""
+      echo "Deploy MaaS platform on a local Kind cluster (macOS + Linux/WSL2)."
+      echo ""
+      echo "Flags:"
+      echo "  --teardown              Delete the Kind cluster and all resources"
+      echo "  --status                Show component status"
+      echo "  --validate              Run inference tests to verify the deployment works"
+      echo "  --rebuild <component>   Rebuild and redeploy a component after code changes"
+      echo "                          Components: bbr, maas-api, maas-controller, all"
+      echo "  --help                  Show this help message"
+      echo ""
+      echo "Environment variables:"
+      echo "  KIND_CLUSTER_NAME     Cluster name (default: maas-local)"
+      echo "  MAAS_API_IMAGE        Custom MaaS API image"
+      echo "  MAAS_CONTROLLER_IMAGE Custom MaaS controller image"
+      exit 0
+      ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+# ─── Teardown ───────────────────────────────────────────────────────────────
+
+if [[ "$ACTION" == "teardown" ]]; then
+  echo -e "${BOLD}Tearing down Kind cluster '${KIND_CLUSTER_NAME}'...${NC}"
+  kind delete cluster --name "$KIND_CLUSTER_NAME" 2>/dev/null || true
+  echo -e "${GREEN}Done.${NC}"
+  exit 0
+fi
+
+# ─── Status ─────────────────────────────────────────────────────────────────
+
+if [[ "$ACTION" == "status" ]]; then
+  echo -e "${BOLD}MaaS Local Deployment Status${NC}"
+  echo ""
+
+  if ! kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
+    fail "Kind cluster '${KIND_CLUSTER_NAME}' not found"
+    exit 1
+  fi
+  ok "Kind cluster '${KIND_CLUSTER_NAME}' exists"
+
+  kubectl config use-context "kind-${KIND_CLUSTER_NAME}" &>/dev/null
+
+  echo ""
+  echo "Pods by namespace:"
+  for ns in istio-system cert-manager kuadrant-system "$MAAS_NAMESPACE"; do
+    echo -e "  ${BOLD}$ns:${NC}"
+    kubectl get pods -n "$ns" --no-headers 2>/dev/null | sed 's/^/    /' || echo "    (none)"
+  done
+
+  echo ""
+  echo "Gateway:"
+  kubectl get gateway -n "$GATEWAY_NAMESPACE" 2>/dev/null | sed 's/^/  /' || echo "  (none)"
+
+  echo ""
+  echo "MaaS CRDs:"
+  kubectl get externalmodels -A 2>/dev/null | sed 's/^/  /' || echo "  (none)"
+  kubectl get maasmodelrefs -A 2>/dev/null | sed 's/^/  /' || echo "  (none)"
+  kubectl get maassubscriptions -A 2>/dev/null | sed 's/^/  /' || echo "  (none)"
+  exit 0
+fi
+
+# ─── Validate ──────────────────────────────────────────────────────────────
+
+if [[ "$ACTION" == "validate" ]]; then
+  if ! kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
+    fail "Kind cluster '${KIND_CLUSTER_NAME}' not found. Run $0 first."
+    exit 1
+  fi
+  kubectl config use-context "kind-${KIND_CLUSTER_NAME}" &>/dev/null
+
+  echo -e "${BOLD}Validating MaaS Local Deployment${NC}"
+  echo ""
+  PASS=0; TOTAL=0
+
+  # All _check inputs are hardcoded strings defined below, not user input.
+  _check() {
+    TOTAL=$((TOTAL + 1))
+    if eval "$2" &>/dev/null; then
+      ok "$1"; PASS=$((PASS + 1))
+    else
+      fail "$1"
+    fi
+  }
+
+  # Pods
+  echo -e "${BOLD}Pods${NC}"
+  _check "All pods running" '[[ $(kubectl get pods -A --no-headers | grep -v Running | grep -v Completed | wc -l) -eq 0 ]]'
+  _check "maas-api ready" 'kubectl get deployment maas-api -n $MAAS_NAMESPACE -o jsonpath="{.status.readyReplicas}" | grep -q 1'
+  _check "maas-controller ready" 'kubectl get deployment maas-controller -n $MAAS_NAMESPACE -o jsonpath="{.status.readyReplicas}" | grep -q 1'
+  _check "payload-processing (BBR) ready" 'kubectl get deployment payload-processing -n $GATEWAY_NAMESPACE -o jsonpath="{.status.readyReplicas}" | grep -q 1'
+  _check "Authorino ready" 'kubectl get deployment authorino -n kuadrant-system -o jsonpath="{.status.readyReplicas}" | grep -q 1'
+  _check "Gateway programmed" 'kubectl get gateway maas-default-gateway -n $GATEWAY_NAMESPACE -o jsonpath="{.status.conditions[?(@.type==\"Programmed\")].status}" | grep -q True'
+
+  # CRDs
+  echo ""
+  echo -e "${BOLD}MaaS Resources${NC}"
+  _check "ExternalModel Ready" '[[ "$(kubectl get maasmodelref llm-katan-openai -n llm -o jsonpath="{.status.phase}")" == "Ready" ]]'
+  _check "LLMInferenceService exists" 'kubectl get llminferenceservice sim-internal -n llm-internal'
+  _check "Subscription Active" '[[ "$(kubectl get maassubscription simulator-subscription -n models-as-a-service -o jsonpath="{.status.phase}")" == "Active" ]]'
+  _check "AuthPolicies created" '[[ $(kubectl get authpolicies -A --no-headers | wc -l) -ge 2 ]]'
+
+  # Inference
+  echo ""
+  echo -e "${BOLD}Inference${NC}"
+
+  # Port-forward (trap ensures cleanup on any exit, including set -e failures)
+  pkill -f "port-forward.*19090" 2>/dev/null || true
+  sleep 1
+  kubectl port-forward -n "$GATEWAY_NAMESPACE" svc/maas-default-gateway-istio 19090:80 > /dev/null 2>&1 &
+  _PF_PID=$!
+  trap 'kill $_PF_PID 2>/dev/null || true' EXIT
+  sleep 3
+
+  # API key
+  API_KEY=$(kubectl exec -n "$MAAS_NAMESPACE" deployment/maas-api -- curl -sk \
+    "https://localhost:8443/v1/api-keys" \
+    -H "X-MaaS-Username: validate-user" \
+    -H 'X-MaaS-Group: ["system:authenticated"]' \
+    -H "Content-Type: application/json" \
+    -d '{"name":"validate"}' 2>/dev/null | jq -r '.key // empty')
+
+  _check "API key creation" '[[ -n "$API_KEY" ]] && [[ "$API_KEY" == sk-oai-* ]]'
+
+  TOTAL=$((TOTAL + 1))
+  MODELS=$(curl -s --max-time 5 http://localhost:19090/v1/models -H "Authorization: Bearer $API_KEY" | jq -r '.data[].id' 2>/dev/null | sort | tr '\n' ',' | sed 's/,$//')
+  if [[ "$MODELS" == *"llm-katan-openai"* ]]; then
+    ok "List models: $MODELS"; PASS=$((PASS + 1))
+  else
+    fail "List models: ${MODELS:-no response}"
+  fi
+
+  TOTAL=$((TOTAL + 1))
+  EXT_RESP=$(curl -s --max-time 15 http://localhost:19090/llm/llm-katan-openai/v1/chat/completions \
+    -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+    -d '{"model":"llm-katan-echo","messages":[{"role":"user","content":"validate"}],"max_tokens":5}' 2>/dev/null)
+  if echo "$EXT_RESP" | jq -e '.choices[0].message.content' &>/dev/null; then
+    ok "External model inference (llm-katan): $(echo "$EXT_RESP" | jq -r .model)"; PASS=$((PASS + 1))
+  else
+    fail "External model inference: ${EXT_RESP:-no response}"
+  fi
+
+  TOTAL=$((TOTAL + 1))
+  INT_RESP=$(curl -s --max-time 15 http://localhost:19090/llm-internal/sim-internal/v1/chat/completions \
+    -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+    -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"validate"}],"max_tokens":5}' 2>/dev/null)
+  if echo "$INT_RESP" | jq -e '.choices[0].message.content' &>/dev/null; then
+    ok "Internal model inference (llm-d sim): $(echo "$INT_RESP" | jq -r .model)"; PASS=$((PASS + 1))
+  else
+    fail "Internal model inference: ${INT_RESP:-no response}"
+  fi
+
+  # Auth
+  echo ""
+  echo -e "${BOLD}Auth${NC}"
+  TOTAL=$((TOTAL + 1))
+  HTTP_NO_KEY=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:19090/v1/models)
+  if [[ "$HTTP_NO_KEY" == "401" ]]; then
+    ok "No API key → 401 Unauthorized"; PASS=$((PASS + 1))
+  else
+    fail "No API key → HTTP $HTTP_NO_KEY (expected 401)"
+  fi
+
+  TOTAL=$((TOTAL + 1))
+  HTTP_BAD_KEY=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:19090/v1/models -H "Authorization: Bearer sk-oai-INVALID")
+  if [[ "$HTTP_BAD_KEY" == "403" ]]; then
+    ok "Invalid API key → 403 Forbidden"; PASS=$((PASS + 1))
+  else
+    fail "Invalid API key → HTTP $HTTP_BAD_KEY (expected 403)"
+  fi
+
+  # TLS
+  echo ""
+  echo -e "${BOLD}TLS${NC}"
+  _check "maas-api cert (cert-manager CA)" 'kubectl get secret maas-api-serving-cert -n $MAAS_NAMESPACE'
+  TOTAL=$((TOTAL + 1))
+  DR_TLS=$(kubectl get dr llm-katan-openai -n llm -o jsonpath='{.spec.trafficPolicy.tls}' 2>/dev/null)
+  if echo "$DR_TLS" | grep -q '"mode":"SIMPLE"' && ! echo "$DR_TLS" | grep -q 'insecureSkipVerify'; then
+    ok "External model TLS: SIMPLE, no insecureSkipVerify"; PASS=$((PASS + 1))
+  else
+    fail "External model TLS: $DR_TLS"
+  fi
+
+  pkill -f "port-forward.*19090" 2>/dev/null || true
+
+  # Summary
+  echo ""
+  if [[ $PASS -eq $TOTAL ]]; then
+    echo -e "${BOLD}${GREEN}All $TOTAL checks passed.${NC}"
+  else
+    echo -e "${BOLD}${YELLOW}$PASS/$TOTAL checks passed.${NC}"
+  fi
+  exit $(( TOTAL - PASS ))
+fi
+
+# ─── Rebuild ───────────────────────────────────────────────────────────────
+
+if [[ "$ACTION" == "rebuild" ]]; then
+  if ! kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
+    fail "Kind cluster '${KIND_CLUSTER_NAME}' not found. Run $0 first."
+    exit 1
+  fi
+  kubectl config use-context "kind-${KIND_CLUSTER_NAME}" &>/dev/null
+
+  # Ensure BBR repo is available
+  if [[ -z "$BBR_REPO" || ! -d "$BBR_REPO" ]]; then
+    BBR_REPO="$PROJECT_ROOT/../ai-gateway-payload-processing"
+    if [[ ! -d "$BBR_REPO" ]]; then
+      echo "  Cloning ai-gateway-payload-processing..."
+      gh repo clone opendatahub-io/ai-gateway-payload-processing "$BBR_REPO" -- --depth 1 2>&1 | tail -1
+    fi
+  fi
+
+  case "$REBUILD_COMPONENT" in
+    bbr|payload-processing)
+      echo -e "${BOLD}Rebuilding BBR (payload-processing)${NC}"
+      (cd "$BBR_REPO" && \
+        docker buildx build --platform "$DOCKER_PLATFORM" --load \
+          -t "$BBR_IMAGE" . 2>&1 | tail -3)
+      kind load docker-image "$BBR_IMAGE" --name "$KIND_CLUSTER_NAME"
+      kubectl rollout restart deployment/payload-processing -n "$GATEWAY_NAMESPACE"
+      kubectl rollout status deployment/payload-processing -n "$GATEWAY_NAMESPACE" --timeout=60s
+      ok "BBR rebuilt and redeployed"
+      ;;
+    maas-api|api)
+      echo -e "${BOLD}Rebuilding maas-api${NC}"
+      (cd "$PROJECT_ROOT/maas-api" && \
+        docker buildx build --platform "$DOCKER_PLATFORM" --load \
+          -t "$MAAS_API_IMAGE" . 2>&1 | tail -3)
+      kind load docker-image "$MAAS_API_IMAGE" --name "$KIND_CLUSTER_NAME"
+      kubectl rollout restart deployment/maas-api -n "$MAAS_NAMESPACE"
+      kubectl rollout status deployment/maas-api -n "$MAAS_NAMESPACE" --timeout=60s
+      ok "maas-api rebuilt and redeployed"
+      ;;
+    maas-controller|controller)
+      echo -e "${BOLD}Rebuilding maas-controller${NC}"
+      (cd "$PROJECT_ROOT" && \
+        docker buildx build --platform "$DOCKER_PLATFORM" --load \
+          -f maas-controller/Dockerfile \
+          -t "$MAAS_CONTROLLER_IMAGE" . 2>&1 | tail -3)
+      kind load docker-image "$MAAS_CONTROLLER_IMAGE" --name "$KIND_CLUSTER_NAME"
+      kubectl rollout restart deployment/maas-controller -n "$MAAS_NAMESPACE"
+      kubectl rollout status deployment/maas-controller -n "$MAAS_NAMESPACE" --timeout=60s
+      ok "maas-controller rebuilt and redeployed"
+      ;;
+    all)
+      echo -e "${BOLD}Rebuilding all components${NC}"
+      echo ""
+      echo "  Building maas-api..."
+      (cd "$PROJECT_ROOT/maas-api" && \
+        docker buildx build --platform "$DOCKER_PLATFORM" --load \
+          -t "$MAAS_API_IMAGE" . 2>&1 | tail -3)
+      kind load docker-image "$MAAS_API_IMAGE" --name "$KIND_CLUSTER_NAME"
+
+      echo "  Building maas-controller..."
+      (cd "$PROJECT_ROOT" && \
+        docker buildx build --platform "$DOCKER_PLATFORM" --load \
+          -f maas-controller/Dockerfile \
+          -t "$MAAS_CONTROLLER_IMAGE" . 2>&1 | tail -3)
+      kind load docker-image "$MAAS_CONTROLLER_IMAGE" --name "$KIND_CLUSTER_NAME"
+
+      echo "  Building BBR..."
+      (cd "$BBR_REPO" && \
+        docker buildx build --platform "$DOCKER_PLATFORM" --load \
+          -t "$BBR_IMAGE" . 2>&1 | tail -3)
+      kind load docker-image "$BBR_IMAGE" --name "$KIND_CLUSTER_NAME"
+
+      kubectl rollout restart deployment/maas-api -n "$MAAS_NAMESPACE"
+      kubectl rollout restart deployment/maas-controller -n "$MAAS_NAMESPACE"
+      kubectl rollout restart deployment/payload-processing -n "$GATEWAY_NAMESPACE"
+      kubectl rollout status deployment/maas-api -n "$MAAS_NAMESPACE" --timeout=60s
+      kubectl rollout status deployment/maas-controller -n "$MAAS_NAMESPACE" --timeout=60s
+      kubectl rollout status deployment/payload-processing -n "$GATEWAY_NAMESPACE" --timeout=60s
+      ok "All components rebuilt and redeployed"
+      ;;
+    *)
+      fail "Unknown component: $REBUILD_COMPONENT"
+      echo "  Valid components: bbr, maas-api, maas-controller, all"
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+# ─── Prerequisites ──────────────────────────────────────────────────────────
+
+step "Checking prerequisites"
+
+# Supported platforms: macOS and Linux (including WSL2)
+OS="$(uname -s)"
+if [[ "$OS" != "Darwin" && "$OS" != "Linux" ]]; then
+  fail "This script supports macOS and Linux. Detected: $OS"
+  exit 1
+fi
+ok "$OS detected ($ARCH)"
+
+# Docker
+if ! docker info &>/dev/null; then
+  fail "Docker is not running. Start Docker (Desktop or daemon) and try again."
+  exit 1
+fi
+
+# Check Docker resources
+DOCKER_CPUS=$(docker info --format '{{.NCPU}}' 2>/dev/null || echo "0")
+DOCKER_MEM_BYTES=$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo "0")
+DOCKER_MEM_GB=$(( DOCKER_MEM_BYTES / 1073741824 ))
+
+if [[ "$DOCKER_CPUS" -lt 4 ]]; then
+  warn "Docker has ${DOCKER_CPUS} CPUs allocated. Recommend 6+ for smooth operation."
+else
+  ok "Docker: ${DOCKER_CPUS} CPUs"
+fi
+if [[ "$DOCKER_MEM_GB" -lt 6 ]]; then
+  warn "Docker has ${DOCKER_MEM_GB}GB RAM allocated. Recommend 8+ GB."
+else
+  ok "Docker: ${DOCKER_MEM_GB}GB RAM"
+fi
+
+# Check disk space
+if [[ "$OS" == "Darwin" ]]; then
+  DISK_FREE_GB=$(df -g / | tail -1 | awk '{print $4}')
+else
+  DISK_FREE_GB=$(df --block-size=1G / | tail -1 | awk '{print $4}')
+fi
+if [[ "$DISK_FREE_GB" -lt 10 ]]; then
+  warn "Only ${DISK_FREE_GB}GB free disk space. Recommend 10+ GB."
+else
+  ok "Disk: ${DISK_FREE_GB}GB free"
+fi
+
+# Required tools
+MISSING=()
+for tool in kind kubectl kustomize helm jq python3 gh; do
+  if ! command -v "$tool" &>/dev/null; then
+    MISSING+=("$tool")
+  fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  fail "Missing required tools: ${MISSING[*]}"
+  if [[ "$OS" == "Darwin" ]]; then
+    echo "  Install with: brew install ${MISSING[*]}"
+  else
+    echo "  Install with your package manager (e.g., apt install ${MISSING[*]})"
+  fi
+  exit 1
+fi
+ok "Tools: kind, kubectl, kustomize, helm, jq"
+
+# istioctl — install inline if missing
+if ! command -v istioctl &>/dev/null; then
+  warn "istioctl not found, installing ${ISTIO_VERSION}..."
+  curl -sL https://istio.io/downloadIstio | ISTIO_VERSION="$ISTIO_VERSION" sh -
+  export PATH="$PWD/istio-${ISTIO_VERSION}/bin:$PATH"
+fi
+ok "istioctl: $(istioctl version --remote=false 2>/dev/null || echo "$ISTIO_VERSION")"
+
+# ─── Step 1: Kind cluster ──────────────────────────────────────────────────
+
+step "Creating Kind cluster"
+
+if kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
+  if kubectl cluster-info --context "kind-${KIND_CLUSTER_NAME}" &>/dev/null; then
+    ok "Cluster '${KIND_CLUSTER_NAME}' already exists and is reachable"
+  else
+    warn "Cluster exists but unreachable, recreating..."
+    kind delete cluster --name "$KIND_CLUSTER_NAME"
+  fi
+fi
+
+if ! kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
+  kind create cluster --name "$KIND_CLUSTER_NAME" --wait 120s --config - <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+EOF
+  ok "Cluster created"
+fi
+
+kubectl config use-context "kind-${KIND_CLUSTER_NAME}"
+
+# ─── Step 2: Gateway API CRDs ──────────────────────────────────────────────
+
+step "Installing Gateway API CRDs"
+
+if kubectl get crd gatewayclasses.gateway.networking.k8s.io &>/dev/null; then
+  ok "Gateway API CRDs already installed"
+else
+  kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v${GATEWAY_API_VERSION}/standard-install.yaml"
+  ok "Gateway API CRDs v${GATEWAY_API_VERSION} installed"
+fi
+
+# ─── Step 3: Istio ──────────────────────────────────────────────────────────
+
+step "Installing Istio (minimal profile)"
+
+if kubectl get deployment istiod -n istio-system &>/dev/null; then
+  ok "Istio already installed"
+else
+  istioctl install --set profile=minimal \
+    --set values.pilot.env.SUPPORT_GATEWAY_API_INFERENCE_EXTENSION=true \
+    --set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true \
+    -y
+  kubectl rollout status deployment/istiod -n istio-system --timeout=120s
+  ok "Istio ${ISTIO_VERSION} installed"
+fi
+
+# ─── Step 3b: MetalLB (LoadBalancer for Kind) ───────────────────────────────
+
+step "Installing MetalLB (LoadBalancer for Kind)"
+
+if kubectl get ipaddresspool kind-pool -n metallb-system &>/dev/null; then
+  ok "MetalLB already installed"
+else
+  if ! kubectl get deployment controller -n metallb-system &>/dev/null; then
+    kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml 2>&1 | tail -3
+  fi
+  kubectl wait --for=condition=Available deployment/controller -n metallb-system --timeout=120s
+
+  # Wait for webhook pod to be ready before applying config (avoids race condition)
+  kubectl wait --for=condition=Ready pod -l component=controller -n metallb-system --timeout=120s 2>/dev/null || true
+
+  # Configure IP pool from Kind's docker network (extract IPv4 subnet)
+  KIND_SUBNET=$(docker network inspect kind -f '{{range .IPAM.Config}}{{.Subnet}} {{end}}' | tr ' ' '\n' | grep '\.')
+  LB_BASE=$(echo "$KIND_SUBNET" | cut -d'.' -f1-3)
+  _metallb_retries=0
+  while [[ $_metallb_retries -lt 6 ]]; do
+    if kubectl apply -f - <<EOF 2>/dev/null
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: kind-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - ${LB_BASE}.200-${LB_BASE}.250
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: kind-l2
+  namespace: metallb-system
+EOF
+    then
+      break
+    fi
+    echo "  MetalLB webhook not ready, retrying in 10s..."
+    sleep 10
+    _metallb_retries=$((_metallb_retries + 1))
+  done
+  ok "MetalLB installed (LB range: ${LB_BASE}.200-250)"
+fi
+
+# ─── Step 4: cert-manager ──────────────────────────────────────────────────
+
+step "Installing cert-manager"
+
+if kubectl get deployment cert-manager -n cert-manager &>/dev/null; then
+  ok "cert-manager already installed"
+else
+  kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/v${CERTMANAGER_VERSION}/cert-manager.yaml"
+  kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
+  kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
+  # Wait for webhook to actually serve (deployment Available != TLS endpoint ready)
+  echo "  Waiting for cert-manager webhook to serve..."
+  _cm_retries=0
+  while [[ $_cm_retries -lt 12 ]]; do
+    if kubectl apply --dry-run=server -f - <<CMEOF 2>/dev/null
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cert-manager-webhook-test
+spec:
+  selfSigned: {}
+CMEOF
+    then
+      break
+    fi
+    sleep 5
+    _cm_retries=$((_cm_retries + 1))
+  done
+  ok "cert-manager v${CERTMANAGER_VERSION} installed"
+fi
+
+# Create TLS certificate for maas-api (replaces OpenShift's service-ca auto-cert).
+# On OpenShift, the service annotation auto-creates the cert via the service-ca controller,
+# and the CA is in the system trust store so Authorino can verify it.
+# On Kind, we use cert-manager with a CA chain (root CA → CA issuer → leaf cert).
+# The root CA cert is then injected into Authorino so it trusts maas-api's cert.
+kubectl create namespace "$MAAS_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+if kubectl get secret maas-api-serving-cert -n "$MAAS_NAMESPACE" &>/dev/null; then
+  ok "TLS certificate for maas-api already exists"
+else
+  kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: maas-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: maas-root-ca
+  namespace: ${MAAS_NAMESPACE}
+spec:
+  isCA: true
+  commonName: maas-ca
+  secretName: maas-root-ca
+  issuerRef:
+    name: maas-selfsigned-issuer
+    kind: ClusterIssuer
+  duration: 87600h
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: maas-ca-issuer
+  namespace: ${MAAS_NAMESPACE}
+spec:
+  ca:
+    secretName: maas-root-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: maas-api-serving-cert
+  namespace: ${MAAS_NAMESPACE}
+spec:
+  secretName: maas-api-serving-cert
+  issuerRef:
+    name: maas-ca-issuer
+    kind: Issuer
+  dnsNames:
+  - maas-api
+  - maas-api.${MAAS_NAMESPACE}
+  - maas-api.${MAAS_NAMESPACE}.svc
+  - maas-api.${MAAS_NAMESPACE}.svc.cluster.local
+  duration: 8760h
+  renewBefore: 720h
+EOF
+  kubectl wait --for=condition=Ready certificate/maas-api-serving-cert \
+    -n "$MAAS_NAMESPACE" --timeout=60s
+  ok "TLS certificate created for maas-api (CA chain)"
+fi
+
+# ─── Step 5: Kuadrant ──────────────────────────────────────────────────────
+
+step "Installing Kuadrant (auth + rate limiting)"
+
+if helm list -n kuadrant-system 2>/dev/null | grep -q kuadrant-operator; then
+  ok "Kuadrant already installed via Helm"
+else
+  helm repo add kuadrant https://kuadrant.io/helm-charts/ 2>/dev/null || true
+  helm repo update kuadrant
+
+  kubectl create namespace kuadrant-system --dry-run=client -o yaml | kubectl apply -f -
+
+  helm upgrade --install kuadrant-operator kuadrant/kuadrant-operator \
+    --namespace kuadrant-system \
+    --version "$KUADRANT_VERSION" \
+    --set manager.env[0].name=ISTIO_GATEWAY_CONTROLLER_NAMES \
+    --set manager.env[0].value=istio.io/gateway-controller \
+    --wait --timeout 180s
+
+  ok "Kuadrant operator v${KUADRANT_VERSION} installed"
+
+  # Create Kuadrant instance
+  kubectl apply -f - <<EOF
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: kuadrant-system
+spec: {}
+EOF
+
+  # Wait for Authorino and Limitador to come up
+  echo "  Waiting for Kuadrant components..."
+  kubectl wait --for=condition=Available deployment -l app=authorino -n kuadrant-system --timeout=120s 2>/dev/null || \
+    warn "Authorino not ready yet (may take a moment)"
+  ok "Kuadrant instance created"
+fi
+
+# Inject maas-api CA cert into Authorino so it can verify maas-api's TLS cert.
+# On OpenShift, the service-ca root CA is in the system trust store. On Kind,
+# we mount the cert-manager root CA and point Go's SSL_CERT_FILE to a combined bundle.
+if ! kubectl get configmap maas-ca-bundle -n kuadrant-system &>/dev/null; then
+  # Wait for Authorino deployment (created asynchronously by Kuadrant operator)
+  echo "  Waiting for Authorino deployment..."
+  for _i in $(seq 1 24); do
+    kubectl get deployment authorino -n kuadrant-system &>/dev/null && break
+    sleep 5
+  done
+  kubectl wait --for=condition=Available deployment/authorino -n kuadrant-system --timeout=120s
+
+  # Extract the root CA cert
+  kubectl get secret maas-root-ca -n "$MAAS_NAMESPACE" -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/maas-ca.crt
+
+  kubectl create configmap maas-ca-bundle -n kuadrant-system \
+    --from-file=maas-ca.crt=/tmp/maas-ca.crt
+
+  # Patch Authorino: add init container to build combined CA bundle, mount it
+  kubectl patch deployment authorino -n kuadrant-system --type=strategic -p '{
+    "spec":{"template":{"spec":{
+      "initContainers":[{
+        "name":"setup-ca",
+        "image":"registry.access.redhat.com/ubi9/ubi-minimal:latest",
+        "command":["/bin/sh","-c"],
+        "args":["cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /maas-ca/maas-ca.crt > /certs/ca-bundle.crt"],
+        "volumeMounts":[
+          {"name":"maas-ca","mountPath":"/maas-ca","readOnly":true},
+          {"name":"combined-certs","mountPath":"/certs"}
+        ]
+      }],
+      "containers":[{
+        "name":"authorino",
+        "env":[{"name":"SSL_CERT_FILE","value":"/certs/ca-bundle.crt"}],
+        "volumeMounts":[{"name":"combined-certs","mountPath":"/certs","readOnly":true}]
+      }],
+      "volumes":[
+        {"name":"maas-ca","configMap":{"name":"maas-ca-bundle"}},
+        {"name":"combined-certs","emptyDir":{}}
+      ]
+    }}}
+  }'
+
+  kubectl rollout status deployment/authorino -n kuadrant-system --timeout=120s
+  rm -f /tmp/maas-ca.crt
+  ok "Authorino CA trust configured for maas-api"
+fi
+
+# ─── Step 6: PostgreSQL ────────────────────────────────────────────────────
+
+step "Deploying PostgreSQL"
+
+kubectl create namespace "$MAAS_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+if kubectl get deployment postgres -n "$MAAS_NAMESPACE" &>/dev/null; then
+  ok "PostgreSQL already deployed"
+else
+  POSTGRES_USER="maas"
+  POSTGRES_DB="maas"
+  POSTGRES_PASSWORD="$(openssl rand -base64 32 | tr -d '/+=' | cut -c1-32)"
+
+  kubectl apply -n "$MAAS_NAMESPACE" -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+  labels:
+    app: postgres
+stringData:
+  POSTGRES_USER: "${POSTGRES_USER}"
+  POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+  POSTGRES_DB: "${POSTGRES_DB}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16-alpine
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgres-creds
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-creds
+              key: POSTGRES_PASSWORD
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: postgres-creds
+              key: POSTGRES_DB
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        readinessProbe:
+          exec:
+            command: ["pg_isready", "-U", "maas"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+  - port: 5432
+    targetPort: 5432
+EOF
+
+  # Create maas-db-config secret
+  ENCODED_PASSWORD=$(printf '%s' "$POSTGRES_PASSWORD" | od -An -tx1 | tr -d ' \n' | sed 's/../%&/g')
+  DB_CONNECTION_URL="postgresql://${POSTGRES_USER}:${ENCODED_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable"
+  create_maas_db_config_secret "$MAAS_NAMESPACE" "$DB_CONNECTION_URL"
+
+  kubectl wait -n "$MAAS_NAMESPACE" --for=condition=available deployment/postgres --timeout=120s
+  ok "PostgreSQL deployed"
+fi
+
+# ─── Step 7: MaaS CRDs ─────────────────────────────────────────────────────
+
+step "Installing MaaS + KServe CRDs"
+
+# Stub OpenShift CRDs — controllers watch these and crash-loop without them on Kind.
+# maas-controller: Authentication.config.openshift.io (Tenant reconciler)
+# kserve-controller: Route.route.openshift.io (InferenceGraph)
+for stub_crd in \
+  "authentications.config.openshift.io:Authentication:AuthenticationList" \
+  "routes.route.openshift.io:Route:RouteList"; do
+  crd_name="${stub_crd%%:*}"
+  rest="${stub_crd#*:}"
+  kind_name="${rest%%:*}"
+  list_name="${rest#*:}"
+  group="${crd_name#*.}"
+  if ! kubectl get crd "$crd_name" &>/dev/null; then
+    kubectl apply -f - <<EOF
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ${crd_name}
+spec:
+  group: ${group}
+  names:
+    kind: ${kind_name}
+    listKind: ${list_name}
+    plural: ${crd_name%%.*}
+    singular: $(echo "${kind_name}" | tr '[:upper:]' '[:lower:]')
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+EOF
+  fi
+done
+
+if kubectl get crd externalmodels.maas.opendatahub.io &>/dev/null; then
+  ok "MaaS CRDs already installed"
+else
+  kubectl apply -f "$PROJECT_ROOT/deployment/base/maas-controller/crd/bases/"
+  for crd in externalmodels.maas.opendatahub.io maasmodelrefs.maas.opendatahub.io \
+             maassubscriptions.maas.opendatahub.io maasauthpolicies.maas.opendatahub.io; do
+    kubectl wait --for=condition=Established "crd/$crd" --timeout=60s
+  done
+  ok "MaaS CRDs installed"
+fi
+
+# KServe LLMInferenceService CRD — required by maas-controller at startup
+if kubectl get crd llminferenceservices.serving.kserve.io &>/dev/null; then
+  ok "KServe CRDs already installed"
+else
+  kubectl apply --server-side -f \
+    "https://raw.githubusercontent.com/opendatahub-io/kserve/${KSERVE_COMMIT}/config/crd/full/serving.kserve.io_llminferenceservices.yaml"
+  kubectl apply --server-side -f \
+    "https://raw.githubusercontent.com/opendatahub-io/kserve/${KSERVE_COMMIT}/config/crd/full/serving.kserve.io_llminferenceserviceconfigs.yaml"
+  kubectl wait --for=condition=Established crd/llminferenceservices.serving.kserve.io --timeout=60s
+  ok "KServe CRDs installed"
+fi
+
+# ─── Step 7b: KServe controller (for LLMInferenceService / internal models) ─
+
+step "Installing KServe (model serving)"
+
+if kubectl get deployment kserve-controller-manager -n kserve &>/dev/null; then
+  ok "KServe already installed"
+else
+  # Install vanilla KServe (provides base controller, CRDs, webhooks)
+  "$PROJECT_ROOT/scripts/installers/install-kserve.sh"
+
+  # Swap to opendatahub fork image (adds LLMInferenceService support)
+  kubectl set image deployment/kserve-controller-manager \
+    manager="$KSERVE_ODH_IMAGE" -n kserve
+  kubectl rollout status deployment/kserve-controller-manager -n kserve --timeout=120s
+  ok "KServe controller installed (opendatahub fork)"
+fi
+
+# LLMInferenceService controller — separate binary in the opendatahub kserve fork
+if kubectl get deployment llmisvc-controller-manager -n kserve &>/dev/null; then
+  ok "LLMIS controller already installed"
+else
+  # Clone opendatahub kserve fork to get the deployment manifests
+  KSERVE_CLONE="/tmp/opendatahub-kserve"
+  if [[ ! -d "$KSERVE_CLONE" ]]; then
+    echo "  Cloning opendatahub-io/kserve..."
+    gh repo clone opendatahub-io/kserve "$KSERVE_CLONE" -- --depth 1 2>&1 | tail -1
+  fi
+
+  # Build arm64 image if needed
+  if [[ "$ARCH" == "arm64" ]]; then
+    echo "  Building llmisvc-controller for arm64..."
+    (cd "$KSERVE_CLONE" && docker buildx build --platform "$DOCKER_PLATFORM" --load \
+      -f llmisvc-controller.Dockerfile \
+      -t "$LLMISVC_IMAGE" . 2>&1 | tail -3)
+    kind load docker-image "$LLMISVC_IMAGE" --name "$KIND_CLUSTER_NAME"
+  fi
+
+  # Deploy the llmisvc controller via kustomize (this also installs CRDs for LLMInferenceServiceConfig)
+  kustomize build "$KSERVE_CLONE/config/llmisvc/" | kubectl apply --server-side -f - 2>&1 | tail -5
+  kubectl rollout status deployment/llmisvc-controller-manager -n kserve --timeout=120s
+
+  # Apply LLMInferenceServiceConfig templates AFTER the CRD and webhook are ready.
+  # These templates tell the LLMIS controller how to create pods, routes, etc.
+  kubectl wait --for=condition=Established crd/llminferenceserviceconfigs.serving.kserve.io --timeout=30s
+  echo "  Waiting for LLMIS webhook to be ready..."
+  _retries=0
+  while [[ $_retries -lt 12 ]]; do
+    if kubectl apply -f "$KSERVE_CLONE/config/llmisvcconfig/config-llm-template.yaml" -n kserve 2>/dev/null; then
+      break
+    fi
+    sleep 5
+    _retries=$((_retries + 1))
+  done
+  for f in "$KSERVE_CLONE"/config/llmisvcconfig/config-*.yaml; do
+    kubectl apply -f "$f" -n kserve
+  done
+  ok "LLMIS controller installed"
+fi
+
+# ─── Step 8: Gateway ───────────────────────────────────────────────────────
+
+step "Creating Gateway"
+
+if kubectl get gateway maas-default-gateway -n "$GATEWAY_NAMESPACE" &>/dev/null; then
+  ok "Gateway already exists"
+else
+  kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: ${GATEWAY_NAMESPACE}
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+EOF
+
+  echo "  Waiting for Gateway to be programmed..."
+  kubectl wait --for=condition=Programmed "gateway/maas-default-gateway" \
+    -n "$GATEWAY_NAMESPACE" --timeout=120s || \
+    warn "Gateway not programmed after 120s (continuing...)"
+  ok "Gateway created in ${GATEWAY_NAMESPACE}"
+fi
+
+# Configure Istio networking for Kind:
+# 1. Permissive mTLS — maas-api pods don't have sidecars
+# 2. NetworkPolicy — allow gateway pods (istio-system) to reach maas-api
+#    (default policy only allows Authorino from kuadrant-system/openshift-operators)
+# TLS origination (gateway → maas-api:8443) is handled by the DestinationRule
+# from the TLS kustomize overlay — no manual DR needed here.
+
+# Clean up old HTTP-mode DestinationRule if present (from previous deployments)
+kubectl delete destinationrule maas-api-no-mtls -n "$MAAS_NAMESPACE" 2>/dev/null || true
+
+if ! kubectl get peerauthentication maas-permissive -n "$MAAS_NAMESPACE" &>/dev/null; then
+  kubectl apply -f - <<EOF
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: maas-permissive
+  namespace: ${MAAS_NAMESPACE}
+spec:
+  mtls:
+    mode: PERMISSIVE
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: maas-gateway-allow
+  namespace: ${MAAS_NAMESPACE}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: maas-api
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ${GATEWAY_NAMESPACE}
+EOF
+  ok "Istio networking configured"
+fi
+
+# ─── Step 9: MaaS controller + API ─────────────────────────────────────────
+
+step "Deploying MaaS controller + API"
+
+# Handle arm64: check if images need local build
+if [[ "$ARCH" == "arm64" ]]; then
+  echo "  Detected Apple Silicon — checking if images need local build..."
+
+  # Check if the image is already loaded in Kind (from a previous run)
+  _needs_build=false
+  if ! docker exec "${KIND_CLUSTER_NAME}-control-plane" crictl images 2>/dev/null | grep -q "maas-api"; then
+    _needs_build=true
+  fi
+
+  if [[ "$_needs_build" == "true" ]]; then
+    warn "quay.io images are x86-only. Building arm64 images locally..."
+
+    echo "  Building maas-api..."
+    (cd "$PROJECT_ROOT/maas-api" && \
+      docker buildx build --platform "$DOCKER_PLATFORM" --load \
+        -t "$MAAS_API_IMAGE" . 2>&1 | tail -3)
+    kind load docker-image "$MAAS_API_IMAGE" --name "$KIND_CLUSTER_NAME"
+
+    echo "  Building maas-controller..."
+    (cd "$PROJECT_ROOT" && \
+      docker buildx build --platform "$DOCKER_PLATFORM" --load \
+        -f maas-controller/Dockerfile \
+        -t "$MAAS_CONTROLLER_IMAGE" . 2>&1 | tail -3)
+    kind load docker-image "$MAAS_CONTROLLER_IMAGE" --name "$KIND_CLUSTER_NAME"
+
+    # Auto-clone BBR repo if not present
+    if [[ -z "$BBR_REPO" || ! -d "$BBR_REPO" ]]; then
+      BBR_REPO="$PROJECT_ROOT/../ai-gateway-payload-processing"
+      if [[ ! -d "$BBR_REPO" ]]; then
+        echo "  Cloning ai-gateway-payload-processing..."
+        gh repo clone opendatahub-io/ai-gateway-payload-processing "$BBR_REPO" -- --depth 1 2>&1 | tail -1
+      fi
+    fi
+
+    echo "  Building payload-processing (BBR)..."
+    (cd "$BBR_REPO" && \
+      docker buildx build --platform "$DOCKER_PLATFORM" --load \
+        -t "$BBR_IMAGE" . 2>&1 | tail -3)
+    kind load docker-image "$BBR_IMAGE" --name "$KIND_CLUSTER_NAME"
+
+    ok "arm64 images built and loaded into Kind"
+  else
+    ok "Images already loaded in Kind"
+  fi
+fi
+
+# Create subscription namespace
+kubectl create namespace "$SUBSCRIPTION_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+# Build kustomize manifests with TLS backend (matching OpenShift's TLS deployment).
+# We create a temp overlay directory with symlinks to the real deployment dirs,
+# because kustomize does not allow absolute paths in resources/components.
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+# Symlink deployment dirs so kustomize can reference them with relative paths
+ln -s "$PROJECT_ROOT/deployment" "$TEMP_DIR/deployment"
+
+# Create Kind-specific params.env
+cat > "$TEMP_DIR/params.env" <<EOF
+maas-api-image=${MAAS_API_IMAGE}
+maas-controller-image=${MAAS_CONTROLLER_IMAGE}
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
+maas-api-key-cleanup-image=docker.io/curlimages/curl:latest
+payload-processing-replicas=1
+gateway-namespace=${GATEWAY_NAMESPACE}
+gateway-name=maas-default-gateway
+app-namespace=${MAAS_NAMESPACE}
+api-key-max-expiration-days=90
+metadata-cache-ttl=60
+authz-cache-ttl=60
+cluster-audience=https://kubernetes.default.svc
+EOF
+
+# Create wrapping kustomization that uses TLS backend with Kind-specific params
+cat > "$TEMP_DIR/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${MAAS_NAMESPACE}
+
+configMapGenerator:
+- envs:
+  - params.env
+  name: maas-parameters
+generatorOptions:
+  disableNameSuffixHash: true
+
+resources:
+  - deployment/base/maas-api/overlays/tls
+  - deployment/base/maas-controller/default
+  - deployment/base/payload-processing/default
+
+components:
+  - deployment/components/shared-patches
+
+patches:
+  - target:
+      kind: NetworkPolicy
+      name: maas-authorino-allow
+    patch: |
+      - op: replace
+        path: /spec/ingress/0/from/0/podSelector/matchLabels
+        value:
+          authorino-resource: authorino
+  # Fix EnvoyFilter subFilter name for Kind (istio-system instead of openshift-ingress)
+  - target:
+      kind: EnvoyFilter
+      name: payload-processing
+    patch: |
+      - op: replace
+        path: /spec/configPatches/0/match/listener/filterChain/filter/subFilter/name
+        value: "extensions.istio.io/wasmplugin/${GATEWAY_NAMESPACE}.kuadrant-maas-default-gateway"
+
+# Payload-processing resources must be in the gateway namespace (same as ODH overlay)
+replacements:
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.payload-processing-image
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - spec.template.spec.containers.[name=payload-processing].image
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.payload-processing-replicas
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - spec.replicas
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-namespace
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: Service
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ServiceAccount
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: DestinationRule
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ConfigMap
+      name: payload-processing-plugins
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ClusterRoleBinding
+      name: payload-processing-reader
+    fieldPaths:
+    - subjects.0.namespace
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-name
+  targets:
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - spec.targetRefs.0.name
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-namespace
+  targets:
+  - select:
+      kind: DestinationRule
+      name: payload-processing
+    fieldPaths:
+    - spec.host
+    options:
+      delimiter: "."
+      index: 1
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - spec.configPatches.0.patch.value.typed_config.grpc_service.envoy_grpc.cluster_name
+    options:
+      delimiter: "."
+      index: 1
+# Replace gateway namespace in maas-api-backend-tls DestinationRule
+# (host replacement is handled by shared-patches component)
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-namespace
+  targets:
+  - select:
+      kind: DestinationRule
+      name: maas-api-backend-tls
+    fieldPaths:
+    - metadata.namespace
+EOF
+
+echo "  Building kustomize manifests..."
+# Filter out PodMonitor and ServiceMonitor resources (require Prometheus Operator CRDs, not needed locally)
+MANIFESTS_FILE="$TEMP_DIR/manifests.yaml"
+kustomize build --load-restrictor LoadRestrictionsNone "$TEMP_DIR" > "$MANIFESTS_FILE"
+
+# Remove monitoring resources that need Prometheus Operator
+python3 -c "
+import sys
+with open('$MANIFESTS_FILE') as f:
+    content = f.read()
+docs = content.split('\n---\n')
+filtered = []
+for doc in docs:
+    if not doc.strip():
+        continue
+    if 'kind: PodMonitor' in doc or 'kind: ServiceMonitor' in doc:
+        continue
+    filtered.append(doc)
+print('\n---\n'.join(filtered))
+" > "$TEMP_DIR/filtered.yaml"
+
+if ! kubectl apply --server-side=true --force-conflicts -f "$TEMP_DIR/filtered.yaml" 2>&1 | tail -15; then
+  fail "Failed to apply MaaS manifests"
+  exit 1
+fi
+
+echo "  Waiting for MaaS API..."
+kubectl rollout status deployment/maas-api -n "$MAAS_NAMESPACE" --timeout=180s 2>/dev/null || \
+  warn "maas-api not ready yet"
+
+# Disable sidecar injection on payload-processing (BBR uses self-signed TLS for ext-proc)
+kubectl patch deployment payload-processing -n "$GATEWAY_NAMESPACE" --type=merge \
+  -p='{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}' 2>/dev/null || true
+
+# Fix controller's GATEWAY_NAMESPACE — base manifest hardcodes openshift-ingress
+CURRENT_GW_NS=$(kubectl get deployment maas-controller -n "$MAAS_NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="GATEWAY_NAMESPACE")].value}' 2>/dev/null)
+if [[ "$CURRENT_GW_NS" != "$GATEWAY_NAMESPACE" ]]; then
+  kubectl set env deployment/maas-controller -n "$MAAS_NAMESPACE" GATEWAY_NAMESPACE="$GATEWAY_NAMESPACE"
+fi
+
+echo "  Waiting for MaaS controller..."
+kubectl rollout status deployment/maas-controller -n "$MAAS_NAMESPACE" --timeout=180s 2>/dev/null || \
+  warn "maas-controller not ready yet"
+
+ok "MaaS controller + API deployed"
+
+# ─── Step 10b: Test fixtures ────────────────────────────────────────────────
+
+step "Deploying test fixtures"
+
+LLM_KATAN_FQDN="${LLM_KATAN_FQDN:-3-13-21-181.sslip.io}"
+MODEL_NAMESPACE="llm"
+INTERNAL_MODEL_NAMESPACE="llm-internal"
+
+kubectl create namespace "$MODEL_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace "$INTERNAL_MODEL_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+# ── External model (ExternalModel → llm-katan on AWS) ──
+if kubectl get externalmodel llm-katan-openai -n "$MODEL_NAMESPACE" &>/dev/null; then
+  ok "External model fixtures already deployed"
+else
+  echo "  Deploying external model (llm-katan)..."
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: llm-katan-creds
+  namespace: ${MODEL_NAMESPACE}
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+stringData:
+  api-key: "llm-katan-openai-key"
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: llm-katan-openai
+  namespace: ${MODEL_NAMESPACE}
+spec:
+  endpoint: "${LLM_KATAN_FQDN}"
+  provider: openai
+  targetModel: llm-katan-echo
+  credentialRef:
+    name: llm-katan-creds
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: llm-katan-openai
+  namespace: ${MODEL_NAMESPACE}
+spec:
+  modelRef:
+    kind: ExternalModel
+    name: llm-katan-openai
+EOF
+  ok "External model deployed"
+fi
+
+# ── Internal model (LLMInferenceService → llm-d simulator in-cluster) ──
+if kubectl get llminferenceservice sim-internal -n "$INTERNAL_MODEL_NAMESPACE" &>/dev/null; then
+  ok "Internal model fixtures already deployed"
+else
+  echo "  Deploying internal model (llm-d simulator)..."
+  kubectl apply -f - <<EOF
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: sim-internal
+  namespace: ${INTERNAL_MODEL_NAMESPACE}
+spec:
+  model:
+    uri: hf://sshleifer/tiny-gpt2
+    name: facebook/opt-125m
+  replicas: 1
+  router:
+    route: {}
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: ${GATEWAY_NAMESPACE}
+  template:
+    containers:
+      - name: main
+        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+        command: ["/app/llm-d-inference-sim"]
+        args:
+        - --port
+        - "8000"
+        - --model
+        - facebook/opt-125m
+        - --mode
+        - random
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+        ports:
+          - name: http
+            containerPort: 8000
+            protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: sim-internal
+  namespace: ${INTERNAL_MODEL_NAMESPACE}
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: sim-internal
+EOF
+  ok "Internal model deployed"
+fi
+
+# ── Shared subscription + auth policy (covers both models) ──
+if kubectl get maassubscription simulator-subscription -n "$SUBSCRIPTION_NAMESPACE" &>/dev/null; then
+  ok "Subscriptions already deployed"
+else
+  echo "  Deploying subscriptions and auth policies..."
+  kubectl apply -f - <<EOF
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: simulator-subscription
+  namespace: ${SUBSCRIPTION_NAMESPACE}
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: llm-katan-openai
+      namespace: ${MODEL_NAMESPACE}
+      tokenRateLimits:
+        - limit: 100
+          window: 1m
+    - name: sim-internal
+      namespace: ${INTERNAL_MODEL_NAMESPACE}
+      tokenRateLimits:
+        - limit: 100
+          window: 1m
+  priority: 10
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: simulator-access
+  namespace: ${SUBSCRIPTION_NAMESPACE}
+spec:
+  modelRefs:
+    - name: llm-katan-openai
+      namespace: ${MODEL_NAMESPACE}
+    - name: sim-internal
+      namespace: ${INTERNAL_MODEL_NAMESPACE}
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []
+EOF
+  ok "Subscriptions and auth policies deployed"
+fi
+
+# Wait for reconciliation
+echo "  Waiting for controller to reconcile fixtures..."
+sleep 20
+EXTERNAL_PHASE=$(kubectl get maasmodelref llm-katan-openai -n "$MODEL_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
+INTERNAL_PHASE=$(kubectl get maasmodelref sim-internal -n "$INTERNAL_MODEL_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
+[[ "$EXTERNAL_PHASE" == "Ready" ]] && ok "External model: Ready" || warn "External model: ${EXTERNAL_PHASE:-unknown}"
+[[ "$INTERNAL_PHASE" == "Ready" ]] && ok "Internal model: Ready" || warn "Internal model: ${INTERNAL_PHASE:-Pending (simulator pod may still be starting)}"
+
+# Note: llm-katan uses Let's Encrypt certs (via certbot + sslip.io), so Istio's
+# tls.mode=SIMPLE cert verification passes without insecureSkipVerify.
+
+# ─── Smoke test ─────────────────────────────────────────────────────────────
+
+step "Running smoke test"
+
+# Port-forward gateway and verify routing works
+kubectl port-forward -n "$GATEWAY_NAMESPACE" svc/maas-default-gateway-istio 19090:80 > /dev/null 2>&1 &
+PF_PID=$!
+sleep 3
+
+# Test direct maas-api health (bypasses gateway)
+HEALTH=$(kubectl exec -n "$MAAS_NAMESPACE" deployment/maas-api -- curl -sk https://localhost:8443/health 2>/dev/null || echo "")
+if [[ "$HEALTH" == *"healthy"* ]]; then
+  ok "MaaS API health check passed"
+else
+  warn "MaaS API health check returned: ${HEALTH:-no response}"
+fi
+
+# Test gateway routing (should get 401 — auth is working)
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:19090/v1/models 2>/dev/null || echo "000")
+if [[ "$HTTP_CODE" == "401" ]]; then
+  ok "Gateway routing + auth working (401 Unauthorized — expected without API key)"
+elif [[ "$HTTP_CODE" == "200" ]]; then
+  ok "Gateway routing working (200 OK)"
+else
+  warn "Gateway returned HTTP ${HTTP_CODE} (may need a moment to stabilize)"
+fi
+
+kill $PF_PID 2>/dev/null
+wait $PF_PID 2>/dev/null || true
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}${GREEN}════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}${GREEN}  MaaS Local Deployment Complete${NC}"
+echo -e "${BOLD}${GREEN}════════════════════════════════════════════════${NC}"
+echo ""
+echo -e "  ${BOLD}Cluster:${NC}     kind-${KIND_CLUSTER_NAME}"
+echo -e "  ${BOLD}Namespace:${NC}   ${MAAS_NAMESPACE}"
+echo -e "  ${BOLD}Gateway:${NC}     maas-default-gateway (${GATEWAY_NAMESPACE})"
+echo ""
+echo -e "  ${BOLD}Test:${NC}"
+echo "    # Port-forward the gateway"
+echo "    kubectl port-forward -n ${GATEWAY_NAMESPACE} svc/maas-default-gateway-istio 8080:80 &"
+echo ""
+echo "    # List models (expect 401 — auth is enforced)"
+echo "    curl -v http://localhost:8080/v1/models"
+echo ""
+echo "    # Direct MaaS API health check (bypasses gateway)"
+echo "    kubectl port-forward -n ${MAAS_NAMESPACE} svc/maas-api 9090:8443 &"
+echo "    curl -k https://localhost:9090/health"
+echo ""
+echo -e "  ${BOLD}Check status:${NC}"
+echo "    $0 --status"
+echo ""
+echo -e "  ${BOLD}Teardown:${NC}"
+echo "    $0 --teardown"
+echo ""

--- a/test/e2e/scripts/local-test.sh
+++ b/test/e2e/scripts/local-test.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Run MaaS E2E tests against a local Kind cluster deployed by local-deploy.sh.
+#
+# This script:
+#   1. Port-forwards the gateway
+#   2. Creates a test token
+#   3. Runs pytest with the right env vars for Kind
+#   4. Cleans up
+#
+# Usage:
+#   ./test/e2e/scripts/local-test.sh                         # Run all local-compatible tests
+#   ./test/e2e/scripts/local-test.sh -k test_create_api_key  # Run specific test
+#   ./test/e2e/scripts/local-test.sh tests/test_api_keys.py  # Run specific file
+#
+# Environment variables:
+#   KIND_CLUSTER_NAME    - Cluster name (default: maas-local)
+#   MAAS_NAMESPACE       - MaaS namespace (default: maas-system)
+#   GATEWAY_NAMESPACE    - Gateway namespace (default: istio-system)
+#   LOCAL_PORT           - Local port for gateway port-forward (default: 19080)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-maas-local}"
+MAAS_NAMESPACE="${MAAS_NAMESPACE:-maas-system}"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-istio-system}"
+LOCAL_PORT="${LOCAL_PORT:-19080}"
+
+# ─── Preflight ──────────────────────────────────────────────────────────────
+
+if ! kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
+  echo "ERROR: Kind cluster '${KIND_CLUSTER_NAME}' not found."
+  echo "Run ./test/e2e/scripts/local-deploy.sh first."
+  exit 1
+fi
+
+kubectl config use-context "kind-${KIND_CLUSTER_NAME}" &>/dev/null
+
+# Verify MaaS API is running
+if ! kubectl get deployment maas-api -n "$MAAS_NAMESPACE" &>/dev/null; then
+  echo "ERROR: maas-api not found in namespace '${MAAS_NAMESPACE}'."
+  echo "Run ./test/e2e/scripts/local-deploy.sh first."
+  exit 1
+fi
+
+# ─── Python venv ────────────────────────────────────────────────────────────
+
+VENV_DIR="${E2E_DIR}/.venv"
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "Creating Python venv..."
+  python3 -m venv "$VENV_DIR" --upgrade-deps
+fi
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+pip install -q -r "$E2E_DIR/requirements.txt"
+
+# ─── Port-forward ──────────────────────────────────────────────────────────
+
+# Kill any existing port-forward on this port
+lsof -ti "tcp:${LOCAL_PORT}" 2>/dev/null | xargs kill 2>/dev/null || true
+
+kubectl port-forward -n "$GATEWAY_NAMESPACE" svc/maas-default-gateway-istio "${LOCAL_PORT}:80" > /dev/null 2>&1 &
+PF_PID=$!
+sleep 3
+
+# Verify port-forward is working
+if ! kill -0 $PF_PID 2>/dev/null; then
+  echo "ERROR: Port-forward failed to start."
+  exit 1
+fi
+
+cleanup() {
+  kill $PF_PID 2>/dev/null
+  wait $PF_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ─── Environment ────────────────────────────────────────────────────────────
+
+export GATEWAY_HOST="localhost:${LOCAL_PORT}"
+export MAAS_API_BASE_URL="http://localhost:${LOCAL_PORT}/maas-api"
+export INSECURE_HTTP="true"
+export E2E_SKIP_TLS_VERIFY="true"
+export DEPLOYMENT_NAMESPACE="$MAAS_NAMESPACE"
+export MAAS_SUBSCRIPTION_NAMESPACE="models-as-a-service"
+
+# Create a K8s service account token for auth
+export TOKEN
+TOKEN=$(kubectl create token maas-api -n "$MAAS_NAMESPACE" --duration=1h --audience=https://kubernetes.default.svc)
+
+# Model name from the test fixtures deployed by local-deploy.sh
+export MODEL_NAME="${MODEL_NAME:-llm-katan-openai}"
+
+# ─── Smoke check ────────────────────────────────────────────────────────────
+
+echo "============================================"
+echo "  MaaS Local E2E Tests"
+echo "============================================"
+echo ""
+echo "  Gateway:  http://localhost:${LOCAL_PORT}"
+echo "  MaaS API: ${MAAS_API_BASE_URL}"
+echo "  Model:    ${MODEL_NAME}"
+echo ""
+
+# Quick sanity check
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://localhost:${LOCAL_PORT}/v1/models" 2>/dev/null || echo "000")
+if [[ "$HTTP_CODE" == "401" ]]; then
+  echo "  Gateway: OK (401 — auth enforced)"
+elif [[ "$HTTP_CODE" == "200" ]]; then
+  echo "  Gateway: OK (200)"
+else
+  echo "  WARNING: Gateway returned HTTP ${HTTP_CODE}"
+fi
+
+HEALTH=$(curl -s --max-time 5 "${MAAS_API_BASE_URL}/health" 2>/dev/null || echo "")
+if [[ "$HEALTH" == *"healthy"* ]]; then
+  echo "  Health:  OK"
+else
+  echo "  WARNING: Health check failed"
+fi
+echo ""
+
+# ─── Run tests ──────────────────────────────────────────────────────────────
+
+# Default: run MaaS management tests (API keys, models endpoint).
+# Model inference tests (TestAPIKeyModelInference) are excluded because they
+# hit the model URL directly from the Mac host, which isn't routable to the
+# Kind docker network. These tests work when BBR + gateway egress is configured.
+#
+# To run all tests: ./local-test.sh --run-all
+# To run specific tests: ./local-test.sh -k test_create_api_key
+
+PYTEST_ARGS=(-v --tb=short)
+RUN_ALL=false
+
+# Parse our args vs pytest args
+PASSTHROUGH_ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --run-all) RUN_ALL=true ;;
+    *) PASSTHROUGH_ARGS+=("$arg") ;;
+  esac
+done
+
+if [[ "$RUN_ALL" == "false" && ${#PASSTHROUGH_ARGS[@]} -eq 0 ]]; then
+  # Default: run MaaS management tests that work with port-forward.
+  #
+  # Excluded tests (require model inference endpoint routable from Mac host):
+  #   TestAPIKeyModelInference    - posts to model /v1/completions
+  #   TestAPIKeyRevocationE2E    (2 of 4) - revoke_then_create, revoke_keys_rejected_at_gateway
+  #   TestAPIKeySubscriptionPhases - creates API keys and hits model endpoint
+  #   test_models_endpoint.py     - api_key fixture hits model endpoint in setup
+  #
+  # These will work once BBR is deployed and gateway egress to llm-katan is configured.
+  PYTEST_ARGS+=(
+    -k "not (TestAPIKeyModelInference or TestAPIKeySubscriptionPhases or test_revoke_keys_rejected_at_gateway or test_revoke_then_create_new_key_works)"
+    "${E2E_DIR}/tests/test_api_keys.py"
+  )
+else
+  PYTEST_ARGS+=("${PASSTHROUGH_ARGS[@]}")
+fi
+
+echo "Running: pytest ${PYTEST_ARGS[*]}"
+echo ""
+
+cd "$E2E_DIR"
+python -m pytest "${PYTEST_ARGS[@]}"


### PR DESCRIPTION
## Summary
Sync `rhoai-3.4` branch with the latest changes from `main` to keep the release branch up to date.

Blocker Jira:
https://redhat.atlassian.net/browse/RHOAIENG-59430

## Description
This PR merges `main` into `rhoai-3.4`, bringing in 7 commits. Merge completed cleanly with no conflicts.

8 files changed (2260 additions, 6 deletions) spanning kustomize patches, CVE fix, Go dependency updates, and new local Kind deployment scripts.

### PRs included

| PR | Description |
|----|-------------|
| [opendatahub-io#794](https://github.com/opendatahub-io/models-as-a-service/pull/794) | chore: promote stable to rhoai |
| [opendatahub-io#793](https://github.com/opendatahub-io/models-as-a-service/pull/793) | chore: promote main to stable |
| [opendatahub-io#792](https://github.com/opendatahub-io/models-as-a-service/pull/792) | fix(kustomize): restore cleanup CronJob image replacement dropped by Tenant refactor |
| [opendatahub-io#781](https://github.com/opendatahub-io/models-as-a-service/pull/781) | fix(cve): cve-2026-33815 - pgx memory-safety |
| [opendatahub-io#775](https://github.com/opendatahub-io/models-as-a-service/pull/775) | feat: local Kind deployment for MaaS + BBR development |

*Additionally includes 2 merge commits from upstream/rhoai syncs.*

## How It Was Tested
- Clean merge with no conflicts verified locally.
- Existing CI checks will validate the merged content.

Made with [Cursor](https://cursor.com)