### PR TITLE
fix: cherry-pick blocker changes for 3.4

### DIFF
--- a/deployment/base/maas-controller/manager/manager.yaml
+++ b/deployment/base/maas-controller/manager/manager.yaml
@@ -45,6 +45,30 @@ spec:
                 fieldPath: metadata.namespace
           - name: MAAS_SUBSCRIPTION_NAMESPACE
             value: "models-as-a-service"
+          - name: RELATED_IMAGE_ODH_MAAS_API_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: maas-api-image
+                name: maas-parameters
+                optional: true
+          - name: RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: maas-controller-image
+                name: maas-parameters
+                optional: true
+          - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: payload-processing-image
+                name: maas-parameters
+                optional: true
+          - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: maas-api-key-cleanup-image
+                name: maas-parameters
+                optional: true
         image: maas-controller
         name: manager
         imagePullPolicy: Always

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -21,6 +21,7 @@ rules:
   resources:
   - endpoints
   - pods
+  - secrets
   verbs:
   - get
   - list
@@ -34,21 +35,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resourceNames:
-  - maas-db-config
-  resources:
-  - secrets
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:

--- a/deployment/components/observability/observability/dashboards/kuadrant-prometheus-datasource.yaml
+++ b/deployment/components/observability/observability/dashboards/kuadrant-prometheus-datasource.yaml
@@ -21,6 +21,6 @@ spec:
         proxy:
           kind: HTTPProxy
           spec:
-            secret: cluster-prometheus-datasource-secret
+            secret: kuadrant-prometheus-datasource-secret
             url: 'https://thanos-querier.openshift-monitoring.svc:9092?namespace=kuadrant-system'
         scrapeInterval: 30s

--- a/deployment/components/observability/observability/dashboards/kustomization.yaml
+++ b/deployment/components/observability/observability/dashboards/kustomization.yaml
@@ -7,8 +7,9 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 resources:
-  - usage-dashboard.yaml
+  - prometheus-web-tls-ca-configmap.yaml
   - kuadrant-prometheus-datasource.yaml
+  - usage-dashboard.yaml
 
 labels:
   - pairs:

--- a/deployment/components/observability/observability/dashboards/prometheus-web-tls-ca-configmap.yaml
+++ b/deployment/components/observability/observability/dashboards/prometheus-web-tls-ca-configmap.yaml
@@ -1,0 +1,12 @@
+# OpenShift service CA bundle for TLS clients (e.g. Perses → Thanos Querier).
+# The service-ca operator injects data.service-ca.crt when the annotation is present.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-web-tls-ca
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-observability
+    app.kubernetes.io/component: perses
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -43,7 +43,6 @@ resources:
   - ../../base/maas-api/overlays/tls  # maas-api with TLS (includes DestinationRule + NetworkPolicy)
   - ../../base/maas-controller/default
   - ../../base/payload-processing/default  # BBR ext_proc for external model payload processing
-  - ../../components/observability/observability/dashboards/
 
 # Include shared-patches component for common configuration
 # This provides: env vars, image replacements, gateway config, URL placeholder fix

--- a/maas-api/deploy/overlays/odh/kustomization.yaml
+++ b/maas-api/deploy/overlays/odh/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ../../../../deployment/base/maas-api/overlays/tls
 - ../../../../deployment/base/maas-controller/policies
 - ../../../../deployment/base/payload-processing/default
+- ../../../../deployment/components/observability/observability/dashboards
 
 namespace: opendatahub
 

--- a/maas-api/deploy/overlays/odh/kustomization.yaml
+++ b/maas-api/deploy/overlays/odh/kustomization.yaml
@@ -11,6 +11,7 @@ metadata:
 resources:
 - ../../../../deployment/base/maas-api/overlays/tls
 - ../../../../deployment/base/maas-controller/policies
+- ../../../../deployment/base/payload-processing/default
 
 namespace: opendatahub
 
@@ -47,3 +48,106 @@ replacements:
       name: maas-api-backend-tls
     fieldPaths:
     - metadata.namespace
+
+# --- payload-processing replacements ---
+# Image
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.payload-processing-image
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - spec.template.spec.containers.[name=payload-processing].image
+# Replicas
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.payload-processing-replicas
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - spec.replicas
+# Payload-processing resources must be in the gateway namespace
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-namespace
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: Service
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ServiceAccount
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: DestinationRule
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ConfigMap
+      name: payload-processing-plugins
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ClusterRoleBinding
+      name: payload-processing-reader
+    fieldPaths:
+    - subjects.0.namespace
+# EnvoyFilter must target the correct gateway name
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-name
+  targets:
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - spec.targetRefs.0.name
+# Gateway namespace in payload-processing DestinationRule host and EnvoyFilter cluster_name
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-namespace
+  targets:
+  - select:
+      kind: DestinationRule
+      name: payload-processing
+    fieldPaths:
+    - spec.host
+    options:
+      delimiter: "."
+      index: 1
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - spec.configPatches.0.patch.value.typed_config.grpc_service.envoy_grpc.cluster_name
+    options:
+      delimiter: "."
+      index: 1

--- a/maas-api/deploy/overlays/odh/params.env
+++ b/maas-api/deploy/overlays/odh/params.env
@@ -8,5 +8,8 @@ gateway-name=maas-default-gateway
 app-namespace=opendatahub
 # Cluster audience for kubernetesTokenReview (overridden by CustomizeParams from Authentication/cluster)
 cluster-audience=https://kubernetes.default.svc
+# Payload-processing image (overridden by RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE env var)
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
+payload-processing-replicas=1
 # API key cleanup CronJob image
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7

--- a/maas-controller/Dockerfile
+++ b/maas-controller/Dockerfile
@@ -28,6 +28,7 @@ RUN chmod +x /manager
 COPY maas-api/deploy /maas-api/deploy
 COPY deployment/base/maas-api /deployment/base/maas-api
 COPY deployment/base/maas-controller/policies /deployment/base/maas-controller/policies
+COPY deployment/base/payload-processing /deployment/base/payload-processing
 COPY deployment/components /deployment/components
 RUN chmod -R g=u /maas-api /deployment
 

--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -27,6 +27,7 @@ RUN chmod +x /manager
 COPY maas-api/deploy /maas-api/deploy
 COPY deployment/base/maas-api /deployment/base/maas-api
 COPY deployment/base/maas-controller/policies /deployment/base/maas-controller/policies
+COPY deployment/base/payload-processing /deployment/base/payload-processing
 COPY deployment/components /deployment/components
 RUN chmod -R g=u /maas-api /deployment
 

--- a/maas-controller/go.mod
+++ b/maas-controller/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/kserve/kserve v0.15.0
 	github.com/onsi/gomega v1.37.0
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.1
 	k8s.io/apiextensions-apiserver v0.33.1
 	k8s.io/apimachinery v0.33.1
@@ -111,7 +112,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -18,6 +18,7 @@ package maas
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -110,6 +111,20 @@ func crdLabeledForMaaSComponent() predicate.Predicate {
 	})
 }
 
+// crdInOptionalAPIGroup matches CRDs belonging to optional platform operator API groups
+// (e.g. perses.dev from COO). CRD names follow the pattern "<plural>.<group>", so a
+// suffix check is sufficient to identify the group without parsing the spec.
+func crdInOptionalAPIGroup() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(o client.Object) bool {
+		for group := range tenantreconcile.OptionalAPIGroups {
+			if strings.HasSuffix(o.GetName(), "."+group) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func secretNamedMaaSDB() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetName() == tenantreconcile.MaaSDBSecretName
@@ -164,6 +179,13 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&extv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueDefaultTenant),
 			builder.WithPredicates(crdLabeledForMaaSComponent()),
+		).
+		// Re-reconcile when optional operator CRDs (e.g. Perses from COO) are installed
+		// so that resources previously skipped due to missing CRDs are applied immediately.
+		Watches(
+			&extv1.CustomResourceDefinition{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueDefaultTenant),
+			builder.WithPredicates(crdInOptionalAPIGroup()),
 		).
 		Watches(
 			&corev1.ConfigMap{},

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -57,8 +57,7 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants/finalizers,verbs=update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups="",resources=secrets,resourceNames=maas-db-config,verbs=get
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;delete

--- a/maas-controller/pkg/platform/tenantreconcile/apply.go
+++ b/maas-controller/pkg/platform/tenantreconcile/apply.go
@@ -8,10 +8,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 )
@@ -134,6 +136,16 @@ func ApplyRendered(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 		// Tenant platform resources. During migration from the ODH modelsasservice
 		// pipeline, force ensures a clean field-manager handoff without conflicts.
 		if err := c.Patch(ctx, u, client.Apply, client.FieldOwner(ssaFieldOwner), client.ForceOwnership); err != nil {
+			if apimeta.IsNoMatchError(err) && isOptionalAPIGroup(u.GroupVersionKind().Group) {
+				// CRD not yet registered for a known optional dependency (e.g. Perses CRDs
+				// installed by COO which may not be present yet). Skip so the rest of the
+				// platform manifests are applied and Tenant reconcile does not fail.
+				// The CRD watch will re-trigger reconcile once the CRDs appear.
+				log.FromContext(ctx).Info("skipping resource: optional CRD not yet registered, will apply once installed",
+					"group", u.GroupVersionKind().Group, "kind", u.GetKind(),
+					"name", u.GetName(), "namespace", u.GetNamespace())
+				continue
+			}
 			return fmt.Errorf("apply %s %s/%s: %w", u.GetKind(), u.GetNamespace(), u.GetName(), err)
 		}
 	}

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -2,7 +2,23 @@
 // (initialize → dependencies → prerequisites → gateway → params → kustomize → post-render → apply → deployment status).
 package tenantreconcile
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// OptionalAPIGroups lists API groups whose CRDs are installed by optional platform
+// components (e.g. COO for Perses). Resources in these groups are skipped gracefully
+// when their CRDs are not yet registered, instead of failing the Tenant reconcile.
+// The CRD watch in the controller re-triggers reconcile once the CRDs appear.
+var OptionalAPIGroups = map[string]bool{
+	"perses.dev": true, // Cluster Observability Operator (COO) — Perses dashboards and datasources
+}
+
+// isOptionalAPIGroup returns true when missing CRDs for the given group should not
+// fail the reconcile (i.e. the dependency is installed by an optional operator).
+func isOptionalAPIGroup(group string) bool {
+	return OptionalAPIGroups[group]
+}
 
 const (
 	// ComponentName matches the ODH modelsasservice component label key suffix (app.opendatahub.io/<name>).

--- a/maas-controller/pkg/platform/tenantreconcile/kustomize.go
+++ b/maas-controller/pkg/platform/tenantreconcile/kustomize.go
@@ -5,56 +5,24 @@ import (
 	"os"
 	"path/filepath"
 
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // no replacement until kustomize API v1
-	"sigs.k8s.io/kustomize/api/filters/namespace"
 	"sigs.k8s.io/kustomize/api/krusty"
-	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
-	"sigs.k8s.io/kustomize/kyaml/resid"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 )
 
-// createNamespaceApplierPlugin mirrors opendatahub-operator/pkg/plugins.CreateNamespaceApplierPlugin.
-func createNamespaceApplierPlugin(targetNamespace string) *builtins.NamespaceTransformerPlugin {
-	return &builtins.NamespaceTransformerPlugin{
-		ObjectMeta: types.ObjectMeta{
-			Name:      "maas-namespace-plugin",
-			Namespace: targetNamespace,
-		},
-		FieldSpecs: []types.FieldSpec{
-			{Gvk: resid.Gvk{}, Path: "metadata/namespace", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{Group: "rbac.authorization.k8s.io", Kind: "ClusterRoleBinding"}, Path: "subjects/namespace", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{Group: "rbac.authorization.k8s.io", Kind: "RoleBinding"}, Path: "subjects/namespace", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration"}, Path: "webhooks/clientConfig/service/namespace", CreateIfNotPresent: false},
-			{Gvk: resid.Gvk{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration"}, Path: "webhooks/clientConfig/service/namespace", CreateIfNotPresent: false},
-			{Gvk: resid.Gvk{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}, Path: "spec/conversion/webhook/clientConfig/service/namespace", CreateIfNotPresent: false},
-		},
-		UnsetOnly:              false,
-		SetRoleBindingSubjects: namespace.AllServiceAccountSubjects,
-	}
-}
+// overlayDefaultNamespace is the namespace hardcoded in the overlay's
+// kustomization.yaml (namespace: opendatahub). postBuildTransform remaps
+// it to the actual appNamespace from the Tenant CR.
+const overlayDefaultNamespace = "opendatahub"
 
-func odhComponentLabels() map[string]string {
-	return map[string]string{
-		LabelODHAppPrefix + "/" + ComponentName: "true",
-		LabelK8sPartOf:                          "models-as-a-service",
-	}
-}
-
-func createSetLabelsPlugin(labels map[string]string) *builtins.LabelTransformerPlugin {
-	return &builtins.LabelTransformerPlugin{
-		Labels: labels,
-		FieldSpecs: []types.FieldSpec{
-			{Gvk: resid.Gvk{Kind: "Deployment"}, Path: "spec/template/metadata/labels", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{Kind: "Deployment"}, Path: "spec/selector/matchLabels", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{}, Path: "metadata/labels", CreateIfNotPresent: true},
-		},
-	}
-}
-
-// RenderKustomize runs kustomize build for the ODH maas-api overlay and applies ODH-equivalent namespace + labels.
+// RenderKustomize runs kustomize build for the ODH maas-api overlay and
+// applies ODH-equivalent namespace remapping and component labels.
 func RenderKustomize(manifestDir, appNamespace string) ([]unstructured.Unstructured, error) {
 	kustomizationPath := manifestDir
 	if !fileExists(filepath.Join(manifestDir, "kustomization.yaml")) {
@@ -68,16 +36,8 @@ func RenderKustomize(manifestDir, appNamespace string) ([]unstructured.Unstructu
 		return nil, fmt.Errorf("kustomize build %q: %w", kustomizationPath, err)
 	}
 
-	if appNamespace != "" {
-		plugin := createNamespaceApplierPlugin(appNamespace)
-		if err := plugin.Transform(resMap); err != nil {
-			return nil, fmt.Errorf("namespace transform: %w", err)
-		}
-	}
-
-	labelPlugin := createSetLabelsPlugin(odhComponentLabels())
-	if err := labelPlugin.Transform(resMap); err != nil {
-		return nil, fmt.Errorf("labels transform: %w", err)
+	if err := postBuildTransform(resMap, appNamespace); err != nil {
+		return nil, fmt.Errorf("post-build transform: %w", err)
 	}
 
 	rendered := resMap.Resources()
@@ -91,6 +51,99 @@ func RenderKustomize(manifestDir, appNamespace string) ([]unstructured.Unstructu
 		out = append(out, unstructured.Unstructured{Object: m})
 	}
 	return out, nil
+}
+
+// postBuildTransform remaps the overlay's hardcoded default namespace to the
+// actual appNamespace and merges ODH component labels into metadata. Unlike the
+// blanket kustomize NamespaceTransformerPlugin + LabelTransformerPlugin, this:
+//   - Leaves cluster-scoped resources (no namespace) untouched
+//   - Preserves cross-namespace resources placed in a non-default namespace by
+//     kustomize replacements (e.g., payload-processing in the gateway namespace)
+//   - Preserves ClusterRoleBinding/RoleBinding subjects with non-default namespaces
+//   - Merges labels into metadata only (not into Deployment selectors, which are
+//     already correct from each base's own kustomization)
+func postBuildTransform(resMap resmap.ResMap, appNamespace string) error {
+	componentLabels := map[string]string{
+		LabelODHAppPrefix + "/" + ComponentName: "true",
+		LabelK8sPartOf:                          "models-as-a-service",
+	}
+
+	for _, res := range resMap.Resources() {
+		// --- namespace remapping (uses RNode API, persists directly) ---
+		if appNamespace != "" {
+			ns := res.GetNamespace()
+			if ns == overlayDefaultNamespace {
+				if err := res.SetNamespace(appNamespace); err != nil {
+					return fmt.Errorf("set namespace on %s %s: %w", res.GetKind(), res.GetName(), err)
+				}
+			}
+
+			if err := remapSubjectNamespaces(res, appNamespace); err != nil {
+				return fmt.Errorf("remap subjects on %s %s: %w", res.GetKind(), res.GetName(), err)
+			}
+		}
+
+		// --- ODH component labels (uses RNode API, persists directly) ---
+		labels := res.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		for k, v := range componentLabels {
+			labels[k] = v
+		}
+		if err := res.SetLabels(labels); err != nil {
+			return fmt.Errorf("set labels on %s %s: %w", res.GetKind(), res.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// remapSubjectNamespaces rewrites ClusterRoleBinding/RoleBinding subjects that
+// reference the overlay default namespace to use appNamespace instead. Uses the
+// RNode Pipe API to mutate the underlying YAML tree directly (res.Map() returns
+// a detached copy that would discard mutations).
+func remapSubjectNamespaces(res *resource.Resource, appNamespace string) error {
+	kind := res.GetKind()
+	if kind != "ClusterRoleBinding" && kind != "RoleBinding" {
+		return nil
+	}
+
+	m, err := res.Map()
+	if err != nil {
+		return fmt.Errorf("map: %w", err)
+	}
+	subjects, ok := m["subjects"].([]any)
+	if !ok {
+		return nil
+	}
+
+	changed := false
+	for _, s := range subjects {
+		subj, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if sns, ok := subj["namespace"].(string); ok && sns == overlayDefaultNamespace {
+			subj["namespace"] = appNamespace
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+
+	// Write modified map back to the RNode via YAML round-trip.
+	m["subjects"] = subjects
+	b, err := yaml.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	node, err := kyaml.Parse(string(b))
+	if err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+	res.ResetRNode((&resource.Resource{RNode: *node}))
+	return nil
 }
 
 // normalizeJSONTypes converts Go int values to int64 in an unstructured map.


### PR DESCRIPTION
## Summary
ecfe542 fix: propagate RELATED_IMAGE env vars to maas-controller for Tenant r… (#808)
2432a0d feat(observability): deploy Perses dashboards via maas-controller (#805)
c18f015 fix(observability): fix Perses datasource secret name and add missing CA ConfigMap (#804)
125aed1 fix(payload-processing): include payload-processing manifests in maas-controller image (#801)

## Tickets
* https://redhat.atlassian.net/browse/RHOAIENG-60046
* https://redhat.atlassian.net/browse/RHOAIENG-59675