### PR TITLE
fix(cve): cve-2026-34986 - go-jose dos [rhoai-3.3]

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.2 // indirect
@@ -104,7 +104,6 @@ require (
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -114,8 +114,8 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.10.1 h1:T0ujvqyCSqRopADpgPgiTT63DUQVSfojyME59Ei63pQ=
 github.com/gin-gonic/gin v1.10.1/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
-github.com/go-jose/go-jose/v4 v4.1.1 h1:JYhSgy4mXXzAdF3nUx3ygx347LRXJRrpgyU3adRmkAI=
-github.com/go-jose/go-jose/v4 v4.1.1/go.mod h1:BdsZGqgdO3b6tTc6LSE56wcDbMMLuPsw5d4ZD5f94kA=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## summary

updates github.com/go-jose/go-jose/v4 from v4.1.1 to v4.1.4 to fix denial of service vulnerability via crafted json web encryption (jwe) object.

### cve details
- **cve id**: CVE-2026-34986
- **package**: github.com/go-jose/go-jose/v4
- **severity**: medium
- **impact**: denial of service — decrypting a jwe object panics if the alg field indicates a key wrapping algorithm and the encrypted_key field is empty
- **vulnerable versions**: < 4.1.4 (v4 series), < 3.0.5 (v3 series)
- **fixed version**: 4.1.4

### changes
- update go-jose/go-jose/v4 from v4.1.1 to v4.1.4 in `maas-api/go.mod`
- run `go mod tidy` to update `maas-api/go.sum`
- no application code changes required

## test results

**status**: ✅ all tests passed

**tests discovered**: yes
**test command**: `go test ./...`
**result**: passed
**packages tested**: api_keys, handlers, models, tier

## breaking changes

none — v4.1.4 is a patch release with no breaking api changes.

## verification checklist

- [x] pre-pr automated tests executed and passed
- [x] go-jose updated from v4.1.1 to v4.1.4
- [x] go mod tidy completed successfully
- [ ] verify cve is resolved with security scan
- [ ] ci/cd pipeline passes

## risk assessment

| factor | assessment |
|--------|-----------|
| change scope | minimal — indirect dependency version bump only |
| breaking changes | none — patch release |
| test coverage | ✅ all existing tests pass |
| rollback | simple — revert go.mod and go.sum |
| overall risk | **low** |

## jira

resolves: RHOAIENG-56853

---

🤖 generated by cve fixer workflow
<!-- cve-fixer-workflow -->