### PR TITLE
fix(cve): cve-2026-33816 - pgx memory-safety

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.9.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/kserve/kserve v0.0.0-20251121160314-57d83d202f36
 	github.com/lib/pq v1.10.9
 	github.com/openai/openai-go/v2 v2.3.1

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -205,8 +205,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=


### PR DESCRIPTION
## summary

update github.com/jackc/pgx/v5 from v5.9.0 to v5.9.2 to resolve memory-safety vulnerability.

### cve details
- **cve id**: CVE-2026-33816
- **package**: github.com/jackc/pgx/v5
- **severity**: memory-safety vulnerability
- **vulnerable versions**: < v5.9.2
- **fixed version**: v5.9.2
- **jira issues**: RHOAIENG-57063

### changes
- update `jackc/pgx/v5` v5.9.0 → v5.9.2 in `maas-api/go.mod`

### test results

**status**: ✅ all tests passed
**test command**: `go test ./...`
**result**: PASSED

<details>
<summary>test summary</summary>

- cmd: PASS
- internal/api_keys: PASS
- internal/auth: PASS
- internal/config: PASS
- internal/handlers: PASS
- internal/subscription: PASS

</details>

### breaking changes
none — minor version patch update within the same v5.x line.

### testing checklist
- [x] pre-pr automated tests executed
- [x] `go test ./...` passes
- [ ] verify cve is resolved with security scan
- [ ] ci/cd pipeline passes

### risk assessment
**risk level**: low — patch update within same major/minor version.

resolves: RHOAIENG-57063

---

🤖 generated by cve fixer workflow
<!-- cve-fixer-workflow -->