### PR TITLE
fix(cve): cve-2026-33816 - pgx memory-safety [rhoai-3.4]

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.9.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/kserve/kserve v0.0.0-20251121160314-57d83d202f36
 	github.com/lib/pq v1.10.9
 	github.com/openai/openai-go/v2 v2.3.1

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -205,8 +205,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=


### PR DESCRIPTION
## CVE Details

| Field | Value |
|-------|-------|
| **CVE ID** | CVE-2026-33816 |
| **Severity** | High |
| **Component** | github.com/jackc/pgx/v5 |
| **Affected Version** | v5.9.0 |
| **Fixed Version** | v5.9.2 |
| **Target Branch** | rhoai-3.4 |

## Summary

- Update `github.com/jackc/pgx/v5` from **v5.9.0** to **v5.9.2** to resolve memory-safety vulnerability in the pgx database driver
- CVE-2026-33816: memory-safety vulnerability in github.com/jackc/pgx

## Changes Made

- Updated `maas-api/go.mod` to require `github.com/jackc/pgx/v5 v5.9.2`
- Ran `go mod tidy` to update `maas-api/go.sum` with new dependency checksums

## Test Results

✅ **All tests passed**

```
ok   github.com/opendatahub-io/models-as-a-service/maas-api/cmd
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/api_keys
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/auth
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/config
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/handlers
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription
```

Command: `cd maas-api && go test ./...`

## Breaking Changes

**None expected.** This is a patch-level dependency update that addresses a security vulnerability without introducing API changes.

## Risk Assessment

**Low** - Patch upgrade of a database driver dependency. All existing tests pass. No API changes expected between v5.9.0 and v5.9.2.

## Jira Reference

RHOAIENG-57063

## Verification Steps

- [ ] CI pipeline passes
- [ ] Confirm `github.com/jackc/pgx/v5 v5.9.2` in go.mod
- [ ] Vulnerability scan no longer reports CVE-2026-33816
- [ ] Application starts and connects to database successfully

<!-- cve-fixer-workflow -->