### PR TITLE
feat: add standalone setup-gateway.sh script for maas-default-gateway (backport to rhoai-3.4)

### DIFF
--- a/docs/content/configuration-and-management/gateway-patterns.md
+++ b/docs/content/configuration-and-management/gateway-patterns.md
@@ -1,0 +1,315 @@
+# Gateway Patterns
+
+This page provides curated Gateway API deployment patterns for MaaS on OpenShift.
+Each pattern includes copy-pasteable YAML manifests, prerequisites, verification steps,
+and troubleshooting guidance for common failure modes.
+
+**Related topics:**
+
+- Default MaaS Gateway setup: [Install MaaS Components — Create Gateway](../install/maas-setup.md#create-gateway)
+- Attaching models to the Gateway: [Model Gateway and Serving](model-gateway-and-serving.md)
+- End-to-end TLS: [TLS Configuration](tls-configuration.md)
+
+## Pattern index
+
+| Pattern | Environment | One-line purpose |
+|---------|-------------|-----------------|
+| [ClusterIP + Route re-encrypt](#clusterip-gateway-with-openshift-route-re-encrypt) | Dev / Lab / Production | ClusterIP Gateway Service fronted by an OpenShift Route with re-encrypt TLS; no external LoadBalancer required |
+
+## Environment matrix
+
+Use this table to decide which pattern fits your deployment:
+
+| Environment | Recommended pattern | Who terminates client TLS? | Internal TLS | Namespace expectations |
+|-------------|--------------------|-----------------------------|-------------|----------------------|
+| **Development / Lab** | ClusterIP + Route re-encrypt | OpenShift Router (wildcard or self-signed cert) | service-ca auto-provisioned cert (re-encrypt to Gateway) | `openshift-ingress` for Gateway and Route; application namespace for HTTPRoute |
+| **Production** | ClusterIP + Route re-encrypt | OpenShift Router (CA-signed certificate) | service-ca auto-provisioned cert (re-encrypt to Gateway) | `openshift-ingress` for Gateway and Route; application namespace for HTTPRoute |
+
+**TLS responsibilities summary:**
+
+- **Client-facing TLS**: Managed by the OpenShift Router. In production, replace the default wildcard certificate with a CA-signed certificate on the IngressController.
+- **Gateway Service TLS**: Auto-provisioned by the OpenShift `service-ca-operator` via the `service.beta.openshift.io/serving-cert-secret-name` annotation. The Secret name in the ConfigMap annotation **must** match the Gateway listener `certificateRefs`.
+- **Authorino and maas-api TLS**: Configured separately. See [TLS Configuration](tls-configuration.md).
+
+## ClusterIP Gateway with OpenShift Route (re-encrypt)
+
+This pattern deploys a Gateway API Gateway as a **ClusterIP** service (no external
+LoadBalancer) and uses an **OpenShift Route** with **re-encrypt** TLS termination
+to expose the Gateway externally.
+
+### Traffic flow
+
+```mermaid
+graph LR
+    Client -->|HTTPS| Router["OpenShift Router"]
+    Router -->|re-encrypt TLS| GWSvc["Gateway Service<br/>ClusterIP:443"]
+    GWSvc --> Envoy["Istio / Envoy"]
+    Envoy -->|HTTPRoute| MaaSAPI["maas-api:8443"]
+```
+
+1. The client connects over HTTPS to the OpenShift Router.
+2. The Router terminates the client TLS session and opens a new TLS connection
+   (re-encrypt) to the Gateway Service using the service-ca certificate.
+3. The Gateway (Istio/Envoy) terminates that connection and routes traffic via
+   HTTPRoute to backend services such as `maas-api`.
+
+### Why ClusterIP + Route?
+
+- **No LoadBalancer required.** Works on bare-metal, restricted cloud accounts,
+  and environments where LoadBalancer provisioning is slow or unavailable.
+- **OpenShift-native ingress.** Leverages the platform Router for TLS termination,
+  hostname routing, and integration with existing wildcard certificates.
+- **Re-encrypt for defense in depth.** Traffic is encrypted between the Router and
+  the Gateway Service, not just at the edge.
+
+### Prerequisites
+
+- OpenShift cluster with Gateway API support (see [Prerequisites](../install/prerequisites.md))
+- GatewayClass `openshift-default` accepted (see [Install Gateway API Controller](../install/platform-setup.md#install-gateway-api-controller))
+- Kuadrant or RHCL operator installed (see [Install Gateway API Controller](../install/platform-setup.md#install-gateway-api-controller))
+- Access to the `openshift-ingress` namespace
+
+### Manifests
+
+All manifests are in
+[`docs/samples/gateway-patterns/clusterip-route-reencrypt/`](https://github.com/opendatahub-io/models-as-a-service/tree/main/docs/samples/gateway-patterns/clusterip-route-reencrypt).
+
+#### 1. GatewayClass
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+spec:
+  controllerName: "openshift.io/gateway-controller/v1"
+```
+
+If `openshift-default` already exists on your cluster, skip this step.
+
+#### 2. Gateway options ConfigMap
+
+The ConfigMap configures the Gateway Service as **ClusterIP** and requests a
+service-ca TLS certificate:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gw-options
+  namespace: openshift-ingress
+data:
+  service: |
+    metadata:
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: "maas-gw-service-tls"
+    spec:
+      type: ClusterIP
+```
+
+| Field | Purpose |
+|-------|---------|
+| `serving-cert-secret-name` | The `service-ca-operator` provisions a TLS certificate into this Secret. Must match the Gateway `certificateRefs`. |
+| `type: ClusterIP` | No external LoadBalancer; the OpenShift Route handles external ingress. |
+
+#### 3. Gateway
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: openshift-ingress
+  labels:
+    kuadrant.io/gateway: "true"
+    app.kubernetes.io/name: maas-gateway
+  annotations:
+    opendatahub.io/managed: "false"
+    security.opendatahub.io/authorino-tls-bootstrap: "true"
+spec:
+  gatewayClassName: openshift-default
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gw-options
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: maas-gw-service-tls
+        mode: Terminate
+```
+
+| Label / Annotation | Purpose |
+|--------------------|---------|
+| `kuadrant.io/gateway: "true"` | Enables Kuadrant/RHCL policy attachment (AuthPolicy, RateLimitPolicy) |
+| `opendatahub.io/managed: "false"` | Lets maas-controller manage AuthPolicies; prevents ODH Model Controller from overwriting them |
+| `security.opendatahub.io/authorino-tls-bootstrap: "true"` | Creates the EnvoyFilter for Gateway → Authorino TLS communication |
+| `infrastructure.parametersRef` | References the `gw-options` ConfigMap for ClusterIP and service-ca configuration |
+
+#### 4. OpenShift Route
+
+The Route exposes the Gateway Service externally with re-encrypt TLS:
+
+```yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: maas-gateway-route
+  namespace: openshift-ingress
+  annotations:
+    router.openshift.io/service-ca-certificate: "true"
+spec:
+  host: maas.<cluster-domain>   # Replace with your cluster domain
+  to:
+    kind: Service
+    name: maas-default-gateway-openshift-default  # Verify with kubectl get svc -n openshift-ingress
+    weight: 100
+  port:
+    targetPort: 443
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+```
+
+!!! warning "Service name"
+    The Gateway controller generates a Service name from the Gateway name and
+    GatewayClass name. Verify the actual name:
+
+    ```bash
+    kubectl get svc -n openshift-ingress \
+      -l gateway.networking.k8s.io/gateway-name=maas-default-gateway
+    ```
+
+!!! warning "Hostname placeholder"
+    Replace `maas.<cluster-domain>` with your actual hostname. Retrieve the
+    cluster domain with:
+
+    ```bash
+    kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}'
+    ```
+
+#### 5. HTTPRoute
+
+Attach workloads to the Gateway. This example routes all traffic to `maas-api`:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: maas-api
+  namespace: <application-namespace>
+spec:
+  parentRefs:
+    - name: maas-default-gateway
+      namespace: openshift-ingress
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: maas-api
+          port: 8443
+```
+
+Replace `<application-namespace>` with your ODH/RHOAI application namespace
+(`opendatahub` or `redhat-ods-applications`).
+
+!!! note
+    The HTTPRoute for maas-api is created automatically by maas-controller
+    by default. You only need to create it manually if you are not using
+    maas-controller.
+
+### Apply
+
+```bash
+# Apply GatewayClass, ConfigMap, and Gateway
+kustomize build docs/samples/gateway-patterns/clusterip-route-reencrypt | kubectl apply -f -
+
+# Wait for the Gateway to be programmed
+kubectl wait --for=condition=Programmed gateway/maas-default-gateway \
+  -n openshift-ingress --timeout=60s
+
+# Determine your cluster domain and the Gateway Service name
+CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+GW_SVC=$(kubectl get svc -n openshift-ingress \
+  -l gateway.networking.k8s.io/gateway-name=maas-default-gateway \
+  -o jsonpath='{.items[0].metadata.name}')
+
+# Create the Route (update host and service name in openshift-route.yaml, or apply inline)
+kubectl apply -f - <<EOF
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: maas-gateway-route
+  namespace: openshift-ingress
+  annotations:
+    router.openshift.io/service-ca-certificate: "true"
+spec:
+  host: maas.${CLUSTER_DOMAIN}
+  to:
+    kind: Service
+    name: ${GW_SVC}
+    weight: 100
+  port:
+    targetPort: 443
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+EOF
+```
+
+### Verify
+
+```bash
+# Gateway should show Programmed=True
+kubectl get gateway maas-default-gateway -n openshift-ingress
+
+# Service should be ClusterIP
+kubectl get svc -n openshift-ingress \
+  -l gateway.networking.k8s.io/gateway-name=maas-default-gateway
+
+# Route should be Admitted
+kubectl get route maas-gateway-route -n openshift-ingress
+
+# TLS certificate Secret should exist
+kubectl get secret maas-gw-service-tls -n openshift-ingress
+```
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Gateway stays `NotProgrammed` | GatewayClass not accepted, or `gw-options` ConfigMap missing | Check `kubectl get gatewayclass`; verify ConfigMap in `openshift-ingress` |
+| Route shows `HostAlreadyClaimed` | Another Route uses the same hostname | Change `spec.host` to a unique FQDN |
+| `503` from the Route | Gateway Service not ready or certificate not yet provisioned | Wait for `service-ca-operator` to provision `maas-gw-service-tls`; check `kubectl get secret -n openshift-ingress` |
+| TLS handshake failure (re-encrypt) | Service CA cert not trusted by the Router | Ensure `router.openshift.io/service-ca-certificate: "true"` annotation on the Route |
+| `certificateRefs` name mismatch | Secret name in Gateway does not match ConfigMap annotation | Verify both reference the same Secret name (`maas-gw-service-tls`) |
+
+## MaaS integration
+
+After deploying a gateway pattern, complete the MaaS-specific steps:
+
+1. **Attach models to the Gateway.** Set `spec.router.gateway.refs` on your
+   LLMInferenceService to point at the deployed Gateway.
+   See [Model Gateway and Serving](model-gateway-and-serving.md).
+
+2. **Configure end-to-end TLS.** Set up Authorino listener TLS and maas-api
+   backend TLS. See [TLS Configuration](tls-configuration.md).
+
+3. **Complete MaaS installation.** If you have not already, follow the full
+   installation flow: database, DataScienceCluster, and validation.
+   See [Install MaaS Components](../install/maas-setup.md).
+
+4. **Deploy sample models.** Use the bundled model samples to verify the
+   gateway is working end-to-end.
+   See [Model Setup](../install/model-setup.md).

--- a/docs/content/configuration-and-management/gateway-patterns.md
+++ b/docs/content/configuration-and-management/gateway-patterns.md
@@ -165,8 +165,6 @@ kind: Route
 metadata:
   name: maas-gateway-route
   namespace: openshift-ingress
-  annotations:
-    router.openshift.io/service-ca-certificate: "true"
 spec:
   host: maas.<cluster-domain>   # Replace with your cluster domain
   to:
@@ -178,6 +176,13 @@ spec:
   tls:
     termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
+    # The router needs the service CA bundle to verify the backend certificate
+    # during reencrypt handshake. Fetch it with:
+    #   kubectl get configmap signing-cabundle -n openshift-service-ca -o jsonpath='{.data.ca-bundle\.crt}'
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      ... (paste service CA bundle here) ...
+      -----END CERTIFICATE-----
 ```
 
 !!! warning "Service name"
@@ -245,6 +250,9 @@ GW_SVC=$(kubectl get svc -n openshift-ingress \
   -l gateway.networking.k8s.io/gateway-name=maas-default-gateway \
   -o jsonpath='{.items[0].metadata.name}')
 
+# Fetch the service CA bundle for reencrypt termination
+SERVICE_CA=$(kubectl get configmap signing-cabundle -n openshift-service-ca -o jsonpath='{.data.ca-bundle\.crt}')
+
 # Create the Route (update host and service name in openshift-route.yaml, or apply inline)
 kubectl apply -f - <<EOF
 apiVersion: route.openshift.io/v1
@@ -252,8 +260,6 @@ kind: Route
 metadata:
   name: maas-gateway-route
   namespace: openshift-ingress
-  annotations:
-    router.openshift.io/service-ca-certificate: "true"
 spec:
   host: maas.${CLUSTER_DOMAIN}
   to:
@@ -265,6 +271,8 @@ spec:
   tls:
     termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
+    destinationCACertificate: |
+$(echo "$SERVICE_CA" | sed 's/^/      /')
 EOF
 ```
 
@@ -292,7 +300,7 @@ kubectl get secret maas-gw-service-tls -n openshift-ingress
 | Gateway stays `NotProgrammed` | GatewayClass not accepted, or `gw-options` ConfigMap missing | Check `kubectl get gatewayclass`; verify ConfigMap in `openshift-ingress` |
 | Route shows `HostAlreadyClaimed` | Another Route uses the same hostname | Change `spec.host` to a unique FQDN |
 | `503` from the Route | Gateway Service not ready or certificate not yet provisioned | Wait for `service-ca-operator` to provision `maas-gw-service-tls`; check `kubectl get secret -n openshift-ingress` |
-| TLS handshake failure (re-encrypt) | Service CA cert not trusted by the Router | Ensure `router.openshift.io/service-ca-certificate: "true"` annotation on the Route |
+| TLS handshake failure (re-encrypt) | Service CA cert not trusted by the Router | Ensure `tls.destinationCACertificate` contains the service CA bundle from `signing-cabundle` ConfigMap in `openshift-service-ca` namespace |
 | `certificateRefs` name mismatch | Secret name in Gateway does not match ConfigMap annotation | Verify both reference the same Secret name (`maas-gw-service-tls`) |
 
 ## MaaS integration

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -19,6 +19,7 @@ Use this platform to streamline the deployment of your models, monitor usage, an
 - **[Subscription limitations and known issues](configuration-and-management/subscription-known-issues.md)** - Rate limits on shared routes, API keys, caching, and other planning notes
 - **[Model Setup (On Cluster)](configuration-and-management/model-setup.md)** - Setting up models for MaaS
 - **[Self-Service Model Access](user-guide/self-service-model-access.md)** - Managing model access and policies
+- **[Gateway Patterns](configuration-and-management/gateway-patterns.md)** - Curated Gateway API deployment patterns
 
 ### 📋 Release Notes
 

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -62,76 +62,47 @@ postgresql://USERNAME:PASSWORD@HOSTNAME:PORT/DATABASE?sslmode=require
 
 ## Create Gateway
 
-The Gateway must exist before enabling modelsAsService in your DataScienceCluster. Create the MaaS Gateway:
+Create `maas-default-gateway` in `openshift-ingress` **before** enabling `modelsAsService` in your DataScienceCluster.
 
-!!! warning "Example Gateway Configuration"
-    The Gateway configuration below is an example. You may need TLS certificates, specific listener settings, or custom infrastructure labels depending on your cluster. For TLS setup, see [TLS Configuration](../configuration-and-management/tls-configuration.md). To quickly apply Authorino TLS for maas-api communication, run:
+`scripts/deploy.sh` runs this step automatically in **route** mode. Run the script yourself when installing via DataScienceCluster first, using **clusterip** mode, or on disconnected clusters.
 
-    ```bash
-    ./scripts/setup-authorino-tls.sh
-    ```
+| Environment | Command |
+|-------------|---------|
+| ROSA, OSD, cloud (default) | `./scripts/setup-gateway.sh` |
+| On-prem, bare-metal, disconnected | `INGRESS_MODE=clusterip ./scripts/setup-gateway.sh` |
+| Air-gapped (no GitHub fetch) | `DISCONNECTED=true INGRESS_MODE=clusterip ./scripts/setup-gateway.sh` |
 
-    **Setting the namespace:** The script defaults to `kuadrant-system` (ODH with Kuadrant). Set `AUTHORINO_NAMESPACE` for RHOAI, which uses RHCL:
+Common overrides: `CLUSTER_DOMAIN`, `CERT_NAME` (route mode only), `DRY_RUN`, `MAAS_MANIFEST_REF` (pinned git ref for remote kustomize fallback). For the full variable list, TLS auto-detection order, and examples, see [scripts/README.md](https://github.com/opendatahub-io/models-as-a-service/blob/main/scripts/README.md#setup-gatewaysh).
 
-    ```bash
-    AUTHORINO_NAMESPACE=rh-connectivity-link ./scripts/setup-authorino-tls.sh
-    ```
+**Verify:**
+
+```bash
+kubectl wait --for=condition=Programmed gateway/maas-default-gateway -n openshift-ingress --timeout=120s
+```
+
+Expected output:
+```
+gateway.gateway.networking.k8s.io/maas-default-gateway condition met
+```
+
+For ClusterIP mode, also verify the Route:
+```bash
+kubectl get route maas-gateway-route -n openshift-ingress
+```
+
+Expected output:
+```
+NAME                  HOST/PORT                           PATH   SERVICES                           PORT   TERMINATION   WILDCARD
+maas-gateway-route    maas.apps.example.cluster.com              maas-default-gateway-openshift-default   443    reencrypt     None
+```
+
+For ClusterIP architecture and troubleshooting, see [Gateway patterns — ClusterIP + Route](../configuration-and-management/gateway-patterns.md#clusterip-gateway-with-openshift-route-re-encrypt).
 
 !!! note "Required annotations"
-    The Gateway **must** include these annotations for MaaS to work correctly:
+    The script applies `opendatahub.io/managed: "false"` and `security.opendatahub.io/authorino-tls-bootstrap: "true"` on the Gateway. See [TLS Configuration](../configuration-and-management/tls-configuration.md) for custom certificates and Authorino integration. The `authorino-tls-bootstrap` annotation is interim until [CONNLINK-528](https://issues.redhat.com/browse/CONNLINK-528).
 
-    | Annotation | Purpose |
-    |------------|---------|
-    | `opendatahub.io/managed: "false"` | Read by **maas-controller**: allows it to manage AuthPolicies and related resources; prevents the ODH Model Controller from overwriting them. |
-    | `security.opendatahub.io/authorino-tls-bootstrap: "true"` | Used by the ODH platform (not maas-controller) to create the EnvoyFilter for Gateway → Authorino TLS when Authorino uses a TLS listener. Required when Authorino TLS is enabled (see [TLS Configuration](../configuration-and-management/tls-configuration.md)). |
-
-```yaml
-CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
-# Use default ingress cert for HTTPS, or set CERT_NAME to your TLS secret name
-CERT_NAME=${CERT_NAME:-$(kubectl get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.spec.defaultCertificate.name}' 2>/dev/null)}
-[[ -z "$CERT_NAME" ]] && CERT_NAME="router-certs-default"
-
-kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: maas-default-gateway
-  namespace: openshift-ingress
-  annotations:
-    opendatahub.io/managed: "false"
-    security.opendatahub.io/authorino-tls-bootstrap: "true"
-spec:
-  gatewayClassName: openshift-default
-  listeners:
-   - name: http
-     hostname: maas.${CLUSTER_DOMAIN}
-     port: 80
-     protocol: HTTP
-     allowedRoutes:
-       namespaces:
-         from: All
-   - name: https
-     hostname: maas.${CLUSTER_DOMAIN}
-     port: 443
-     protocol: HTTPS
-     allowedRoutes:
-       namespaces:
-         from: All
-     tls:
-       certificateRefs:
-       - group: ""
-         kind: Secret
-         name: ${CERT_NAME}
-       mode: Terminate
-EOF
-```
-
-!!! note "TLS certificate"
-    The HTTPS listener uses a Secret in `openshift-ingress`. The script auto-detects the default ingress cert; if that fails, it uses `router-certs-default`. If the Gateway fails to program, ensure the Secret exists: `kubectl get secret -n openshift-ingress`. See [TLS Configuration](../configuration-and-management/tls-configuration.md) for custom certs.
-
-```shell
-kubectl wait --for=condition=Programmed gateway/maas-default-gateway -n openshift-ingress --timeout=60s
-```
+!!! tip "Authorino TLS"
+    After the Gateway exists, run `./scripts/setup-authorino-tls.sh`. For RHOAI/RHCL, set `AUTHORINO_NAMESPACE=rh-connectivity-link`.
 
 ## Configure DataScienceCluster
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Namespace User Permissions (RBAC): configuration-and-management/namespace-rbac.md
       - TLS Configuration: configuration-and-management/tls-configuration.md
       - Subscription limitations & known issues: configuration-and-management/subscription-known-issues.md
+      - Gateway Patterns: configuration-and-management/gateway-patterns.md
     - Models:
       - Model Setup (On Cluster): configuration-and-management/model-setup.md
       - Model Listing Flow: configuration-and-management/model-listing-flow.md

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/README.md
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/README.md
@@ -1,0 +1,104 @@
+# ClusterIP Gateway with OpenShift Route (Re-encrypt)
+
+A Gateway API pattern that uses a **ClusterIP** service (no external LoadBalancer) with an
+**OpenShift Route** providing external ingress and **re-encrypt** TLS termination.
+
+## When to use
+
+- OpenShift clusters where you want the platform Router to handle external TLS
+  (wildcard or custom certificate) and re-encrypt traffic to the Gateway Service.
+- Environments where LoadBalancer services are unavailable or undesirable
+  (e.g., bare-metal, restricted cloud accounts).
+- Production and lab environments that already use OpenShift Routes for ingress.
+
+## How it works
+
+```
+Client ──HTTPS──▶ OpenShift Router ──re-encrypt──▶ Gateway Service (ClusterIP:443)
+                                                       │
+                                                       ▼
+                                                   Istio/Envoy
+                                                       │
+                                                   HTTPRoute
+                                                       │
+                                                       ▼
+                                                   maas-api (8443)
+```
+
+1. **GatewayClass** registers the OpenShift gateway controller.
+2. **ConfigMap `gw-options`** configures the Gateway Service as `ClusterIP` and
+   requests a service-ca TLS certificate via annotation.
+3. **Gateway** listens on HTTPS/443 with TLS `Terminate` mode, using the
+   auto-provisioned certificate.
+4. **OpenShift Route** fronts the Gateway Service with `reencrypt` TLS — the
+   Router terminates the client session and opens a new TLS connection to the
+   Gateway using the service-ca certificate.
+5. **HTTPRoute** attaches workloads (e.g., maas-api) to the Gateway.
+
+## Prerequisites
+
+- OpenShift cluster with Gateway API support
+- Gateway API CRDs installed (included with OpenShift)
+- Kuadrant / RHCL operator installed (see [Platform Setup](../../../content/install/platform-setup.md))
+- `openshift-ingress` namespace accessible
+
+## Apply
+
+```bash
+# 1. Apply GatewayClass, ConfigMap, and Gateway
+kustomize build docs/samples/gateway-patterns/clusterip-route-reencrypt | kubectl apply -f -
+
+# 2. Wait for the Gateway to be programmed
+kubectl wait --for=condition=Programmed gateway/maas-default-gateway \
+  -n openshift-ingress --timeout=60s
+
+# 3. Identify the Gateway Service name
+GW_SVC=$(kubectl get svc -n openshift-ingress -l gateway.networking.k8s.io/gateway-name=maas-default-gateway -o jsonpath='{.items[0].metadata.name}')
+echo "Gateway Service: ${GW_SVC}"
+
+# 4. Create the OpenShift Route (edit openshift-route.yaml first to set your hostname and Service name)
+# Replace <cluster-domain> with your cluster's apps domain:
+#   CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+# Replace the Service name if it differs from maas-default-gateway-openshift-default.
+kubectl apply -f docs/samples/gateway-patterns/clusterip-route-reencrypt/openshift-route.yaml
+
+# 5. Apply HTTPRoute (edit httproute.yaml to set your application namespace)
+kubectl apply -f docs/samples/gateway-patterns/clusterip-route-reencrypt/httproute.yaml
+```
+
+## Verify
+
+```bash
+# Gateway should show Programmed=True
+kubectl get gateway maas-default-gateway -n openshift-ingress
+
+# Gateway Service should be ClusterIP
+kubectl get svc -n openshift-ingress -l gateway.networking.k8s.io/gateway-name=maas-default-gateway
+
+# Route should be Admitted
+kubectl get route maas-gateway-route -n openshift-ingress
+
+# TLS certificate should be provisioned
+kubectl get secret maas-gw-service-tls -n openshift-ingress
+```
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Gateway stays `NotProgrammed` | GatewayClass not accepted, or ConfigMap `gw-options` missing | Check `kubectl get gatewayclass`; verify ConfigMap exists in `openshift-ingress` |
+| Route shows `HostAlreadyClaimed` | Another Route uses the same hostname | Change `spec.host` to a unique FQDN |
+| `503` from the Route | Gateway Service not ready or certificate not yet provisioned | Wait for service-ca to provision `maas-gw-service-tls`; check `kubectl get secret -n openshift-ingress` |
+| TLS handshake failure (re-encrypt) | Service CA cert not trusted by Router | Ensure `router.openshift.io/service-ca-certificate: "true"` is set on the Route |
+| `certificateRefs` name mismatch | Secret name in Gateway does not match ConfigMap annotation | Verify both reference the same Secret name |
+
+## Customization
+
+- **Hostname**: Replace `maas.<cluster-domain>` in `openshift-route.yaml` with your
+  actual cluster domain or a custom hostname.
+- **Custom TLS certificate**: Replace the service-ca annotation with a manually
+  provisioned Secret and update both the ConfigMap and Gateway `certificateRefs`.
+- **Multiple listeners**: Add additional listeners to the Gateway for different
+  hostnames or protocols.
+- **Kuadrant labels**: The `kuadrant.io/gateway: "true"` label is required for
+  Kuadrant/RHCL policy attachment (RateLimitPolicy, AuthPolicy).

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway-class.yaml
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway-class.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+spec:
+  controllerName: "openshift.io/gateway-controller/v1"

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway-options-configmap.yaml
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway-options-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gw-options
+  namespace: openshift-ingress
+data:
+  # See https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/
+  service: |
+    metadata:
+      annotations:
+        # OpenShift service-ca-operator auto-provisions a TLS certificate into this Secret.
+        # The Secret name here MUST match the certificateRefs in the Gateway listener.
+        service.beta.openshift.io/serving-cert-secret-name: "maas-gw-service-tls"
+    spec:
+      # ClusterIP avoids provisioning an external LoadBalancer; the OpenShift Route
+      # handles external ingress instead.
+      type: ClusterIP

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway.yaml
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: openshift-ingress
+  labels:
+    kuadrant.io/gateway: "true"
+    app.kubernetes.io/name: maas-gateway
+  annotations:
+    opendatahub.io/managed: "false"
+    security.opendatahub.io/authorino-tls-bootstrap: "true"
+spec:
+  gatewayClassName: openshift-default
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gw-options
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            # Must match the serving-cert-secret-name in gw-options ConfigMap.
+            # service-ca-operator populates this Secret automatically.
+            name: maas-gw-service-tls
+        mode: Terminate

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/httproute.yaml
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/httproute.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: maas-api
+  namespace: <application-namespace>
+spec:
+  parentRefs:
+    - name: maas-default-gateway
+      namespace: openshift-ingress
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: maas-api
+          port: 8443

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/kustomization.yaml
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - gateway-class.yaml
+  - gateway-options-configmap.yaml
+  - gateway.yaml

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/openshift-route.yaml
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/openshift-route.yaml
@@ -1,0 +1,25 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: maas-gateway-route
+  namespace: openshift-ingress
+  annotations:
+    # Tells the OpenShift Router to trust the service-ca certificate on the backend.
+    router.openshift.io/service-ca-certificate: "true"
+spec:
+  # Replace with your actual hostname.
+  host: maas.<cluster-domain>
+  to:
+    kind: Service
+    # The Gateway controller creates a Service whose name is derived from the
+    # Gateway name and GatewayClass name. Verify with:
+    #   kubectl get svc -n openshift-ingress | grep maas-default-gateway
+    name: maas-default-gateway-openshift-default
+    weight: 100
+  port:
+    targetPort: 443
+  tls:
+    # Re-encrypt: the Router terminates the client TLS session and opens a new
+    # TLS connection to the Gateway Service using the service-ca certificate.
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/openshift-route.yaml
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/openshift-route.yaml
@@ -3,9 +3,6 @@ kind: Route
 metadata:
   name: maas-gateway-route
   namespace: openshift-ingress
-  annotations:
-    # Tells the OpenShift Router to trust the service-ca certificate on the backend.
-    router.openshift.io/service-ca-certificate: "true"
 spec:
   # Replace with your actual hostname.
   host: maas.<cluster-domain>
@@ -23,3 +20,12 @@ spec:
     # TLS connection to the Gateway Service using the service-ca certificate.
     termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
+    # Provide the service CA bundle so the router can verify the backend certificate.
+    # Fetch the CA bundle with:
+    #   kubectl get configmap signing-cabundle -n openshift-service-ca -o jsonpath='{.data.ca-bundle\.crt}'
+    # Without this, reencrypt handshake will fail on clusters where the router
+    # doesn't implicitly trust service-ca (e.g., bare-metal, disconnected).
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      ... (paste the service CA bundle here) ...
+      -----END CERTIFICATE-----

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -196,6 +196,43 @@ AUTHORINO_NAMESPACE=rh-connectivity-link ./scripts/setup-authorino-tls.sh
 
 ---
 
+### `setup-gateway.sh`
+Creates `maas-default-gateway` Gateway API resource for MaaS.
+
+**Usage:**
+```bash
+# Route mode (ROSA, OSD, cloud clusters - default)
+./scripts/setup-gateway.sh
+
+# ClusterIP mode (on-prem, disconnected, bare-metal)
+INGRESS_MODE=clusterip ./scripts/setup-gateway.sh
+
+# Disconnected environment (no GitHub fallback)
+DISCONNECTED=true INGRESS_MODE=clusterip ./scripts/setup-gateway.sh
+
+# Preview changes without applying
+DRY_RUN=true ./scripts/setup-gateway.sh
+```
+
+**What it does:**
+- Creates GatewayClass (`openshift-default`)
+- **Route mode:** Creates Gateway with LoadBalancer Service and auto-detected TLS certificate
+- **ClusterIP mode:** Creates ConfigMap/gw-options, Gateway with ClusterIP Service, OpenShift Route with reencrypt termination
+- Auto-detects cluster domain and TLS certificate (four-level fallback in route mode)
+- Waits for Gateway to be Programmed
+
+**Environment Variables:**
+- `INGRESS_MODE` - Deployment mode: `route` (default) or `clusterip`
+- `CLUSTER_DOMAIN` - Override cluster domain auto-detection
+- `CERT_NAME` - Override TLS certificate secret name (route mode only)
+- `DISCONNECTED` - Disable GitHub manifest fallback (`true`/`false`, default: false)
+- `DRY_RUN` - Preview changes without applying (`true`/`false`, default: false)
+- `MAAS_MANIFEST_REF` - Git tag or commit SHA for remote kustomize fallback (defaults to current repo `HEAD` when run from a clone; required when fetching without a local tree)
+
+**Note:** Route mode auto-detects cluster TLS certificates. Override with `CERT_NAME` if needed.
+
+---
+
 ### `install-dependencies.sh`
 Installs individual dependencies (Kuadrant, ODH, etc.).
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1211,133 +1211,6 @@ apply_dsc() {
 }
 
 #──────────────────────────────────────────────────────────────
-# GATEWAY API SETUP
-#──────────────────────────────────────────────────────────────
-
-# setup_gateway_api
-#   Sets up the Gateway API infrastructure (GatewayClass).
-#   This is general Gateway API setup that can be used by any Gateway resources.
-setup_gateway_api() {
-  log_info "Setting up Gateway API infrastructure..."
-
-  local data_dir="${SCRIPT_DIR}/data"
-
-  # Create GatewayClass for OpenShift Gateway API controller
-  # This enables the built-in Gateway API implementation (OpenShift 4.14+)
-  if kubectl get gatewayclass openshift-default &>/dev/null; then
-    log_debug "GatewayClass openshift-default already exists, skipping creation"
-  else
-    log_info "Creating GatewayClass openshift-default..."
-    kubectl apply -f "${data_dir}/gatewayclass.yaml"
-  fi
-}
-
-# setup_maas_gateway
-#   Creates the Gateway resource required by ModelsAsService component.
-#   ModelsAsService expects a gateway named "maas-default-gateway" in namespace "openshift-ingress".
-#
-#   This function:
-#   1. Detects or uses the router's TLS certificate
-#   2. Creates the Gateway resource with both HTTP and HTTPS listeners
-#   3. Uses the kustomize manifest from deployment/base/networking/maas/
-#
-#   The Gateway includes:
-#   - HTTP listener (port 80) - required for model discovery URLs
-#   - HTTPS listener (port 443) - for secure API access
-#   - Annotations for operator management and TLS bootstrap
-#   - Labels for app identification
-setup_maas_gateway() {
-  log_info "Setting up ModelsAsService gateway..."
-
-  # Get cluster domain for Gateway hostname
-  local cluster_domain
-  cluster_domain=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "")
-  if [[ -z "$cluster_domain" ]]; then
-    log_error "Could not determine cluster domain - required for Gateway hostname"
-    return 1
-  fi
-  
-  export CLUSTER_DOMAIN="$cluster_domain"
-  log_info "  Cluster domain: ${CLUSTER_DOMAIN}"
-
-  # Detect TLS certificate if not explicitly set (matches upstream deploy-rhoai-stable.sh logic)
-  local cert_name="${CERT_NAME:-}"
-  if [[ -z "$cert_name" ]]; then
-    log_info "  Detecting TLS certificate secret..."
-
-    # Primary: Get certificate from IngressController (most reliable source of truth)
-    cert_name=$(kubectl get ingresscontroller default -n openshift-ingress-operator \
-      -o jsonpath='{.spec.defaultCertificate.name}' 2>/dev/null || echo "")
-    if [[ -n "$cert_name" ]] && kubectl get secret -n openshift-ingress "$cert_name" &>/dev/null; then
-      log_info "  * Found certificate from IngressController: ${cert_name}"
-    else
-      [[ -n "$cert_name" ]] && log_debug "  * IngressController cert '${cert_name}' not found, trying alternatives..."
-      cert_name=""
-    fi
-
-    # Fallback 1: Get certificate from router deployment
-    if [[ -z "$cert_name" ]]; then
-      cert_name=$(kubectl get deployment router-default -n openshift-ingress \
-        -o jsonpath='{.spec.template.spec.volumes[?(@.name=="default-certificate")].secret.secretName}' 2>/dev/null || echo "")
-      if [[ -n "$cert_name" ]] && kubectl get secret -n openshift-ingress "$cert_name" &>/dev/null; then
-        log_info "  * Found certificate from router deployment: ${cert_name}"
-      else
-        cert_name=""
-      fi
-    fi
-
-    # Fallback 2: Check known certificate secret names
-    if [[ -z "$cert_name" ]]; then
-      local cert_candidates=("default-gateway-cert" "router-certs-default")
-      for cert in "${cert_candidates[@]}"; do
-        if kubectl get secret -n openshift-ingress "$cert" &>/dev/null; then
-          cert_name="$cert"
-          log_info "  * Found TLS certificate secret: ${cert}"
-          break
-        fi
-      done
-    fi
-
-    # Warning if no certificate found
-    if [[ -z "$cert_name" ]]; then
-      log_warn "  No TLS certificate found. Creating self-signed certificate..."
-      local gateway_hostname="maas.${cluster_domain}"
-      if create_tls_secret "maas-gateway-tls" "openshift-ingress" "${gateway_hostname}"; then
-        cert_name="maas-gateway-tls"
-        log_info "  * Created self-signed certificate: ${cert_name}"
-      else
-        log_error "Failed to create TLS certificate for gateway"
-        return 1
-      fi
-    fi
-  fi
-
-  export CERT_NAME="$cert_name"
-  log_info "  TLS certificate secret: ${CERT_NAME}"
-
-  # Create the Gateway resource using the kustomize manifest
-  # This includes both HTTP and HTTPS listeners, required annotations and labels
-  if kubectl get gateway maas-default-gateway -n openshift-ingress &>/dev/null; then
-    log_info "Gateway maas-default-gateway already exists in openshift-ingress"
-    log_debug "  Updating Gateway configuration if needed..."
-  else
-    log_info "Creating maas-default-gateway resource (allowing routes from all namespaces)..."
-  fi
-
-  local maas_networking_dir="${SCRIPT_DIR}/../deployment/base/networking/maas"
-  if [[ -d "$maas_networking_dir" ]]; then
-    # Use local kustomize manifest with envsubst for variable substitution
-    kustomize build "$maas_networking_dir" | envsubst '$CLUSTER_DOMAIN $CERT_NAME' | kubectl apply --server-side=true -f -
-  else
-    # Fallback: fetch from GitHub (for standalone script usage)
-    log_debug "  Local manifest not found, fetching from GitHub..."
-    kubectl apply --server-side=true \
-      -f <(kustomize build "https://github.com/opendatahub-io/models-as-a-service.git/deployment/base/networking/maas?ref=main" | \
-           envsubst '$CLUSTER_DOMAIN $CERT_NAME')
-  fi
-}
-
-#──────────────────────────────────────────────────────────────
 # KUADRANT SETUP
 #──────────────────────────────────────────────────────────────
 
@@ -1346,18 +1219,19 @@ apply_kuadrant_cr() {
 
   log_info "Initializing Gateway API and ModelsAsService gateway..."
 
-  # Setup Gateway API infrastructure (can be used by any Gateway resources)
-  setup_gateway_api
-
-  # Setup ModelsAsService-specific gateway (required by ModelsAsService component)
-  setup_maas_gateway
-
-  # Wait for Gateway to be Programmed (required before Kuadrant can become ready)
-  # This ensures Service Mesh is installed and Gateway API provider is operational
-  log_info "Waiting for Gateway to be Programmed (Service Mesh initialization)..."
-  if ! kubectl wait --for=condition=Programmed gateway/maas-default-gateway -n openshift-ingress --timeout="${CUSTOM_CHECK_TIMEOUT}s" 2>/dev/null; then
-    log_warn "Gateway not yet Programmed after ${CUSTOM_CHECK_TIMEOUT}s - Kuadrant may take longer to become ready"
-  fi
+  # Setup Gateway using standalone script (replaces inline setup_gateway_api + setup_maas_gateway)
+  # The script handles GatewayClass creation, Gateway creation with TLS cert detection,
+  # and waits for Gateway to be Programmed before returning.
+  INGRESS_MODE="${INGRESS_MODE:-route}" \
+  DISCONNECTED="${DISCONNECTED:-false}" \
+  CLUSTER_DOMAIN="${CLUSTER_DOMAIN:-}" \
+  CERT_NAME="${CERT_NAME:-}" \
+  DRY_RUN="${DRY_RUN:-false}" \
+  MAAS_MANIFEST_REF="${MAAS_MANIFEST_REF:-}" \
+  "${SCRIPT_DIR}/setup-gateway.sh" || {
+    log_error "Gateway setup failed"
+    return 1
+  }
 
   log_info "Applying Kuadrant custom resource in $namespace..."
 

--- a/scripts/setup-gateway.sh
+++ b/scripts/setup-gateway.sh
@@ -1,0 +1,633 @@
+#!/bin/bash
+#
+# Create maas-default-gateway for Models-as-a-Service.
+#
+# Two deployment modes cover the full environment matrix:
+#
+# INGRESS_MODE     Service type            TLS source                         Best for
+# -------------    ---------------------   --------------------------------   ------------------
+# route (default)  Gateway-controller      Cluster router cert                ROSA, OSD, cloud
+#                  default (LoadBalancer)  (auto-detected, four-level
+#                                          fallback: IngressController →
+#                                          router deployment → known
+#                                          secrets → self-signed)
+#
+# clusterip        ClusterIP + OCP Route   service-ca-operator                On-prem,
+#                  (reencrypt)             (auto-provisioned)                 disconnected,
+#                                                                             bare-metal
+#
+# The clusterip mode applies all required resources in order:
+#   ConfigMap/gw-options → Gateway → wait for Programmed → Route/maas-gateway-route
+#
+# The DISCONNECTED=true flag removes the GitHub fallback and fails fast if local
+# manifests are missing.
+#
+# Environment variables:
+#   INGRESS_MODE       "route" (default) or "clusterip"
+#   DISCONNECTED       "true" to disable GitHub manifest fallback (default: false)
+#   CLUSTER_DOMAIN     Override cluster domain auto-detection
+#   CERT_NAME          Override TLS certificate secret name (route mode only)
+#   DRY_RUN            "true" to preview without applying (default: false)
+#   MAAS_MANIFEST_REF  Git tag or commit SHA for remote kustomize fallback (route mode)
+#
+# Usage:
+#   # Route mode (ROSA, OSD, cloud)
+#   ./scripts/setup-gateway.sh
+#
+#   # ClusterIP mode (on-prem, disconnected)
+#   INGRESS_MODE=clusterip ./scripts/setup-gateway.sh
+#
+#   # Disconnected environment (no GitHub fetch)
+#   DISCONNECTED=true INGRESS_MODE=clusterip ./scripts/setup-gateway.sh
+#
+
+set -euo pipefail
+
+# Source helpers
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deployment-helpers.sh
+source "${SCRIPT_DIR}/deployment-helpers.sh"
+
+#──────────────────────────────────────────────────────────────
+# CONFIGURATION
+#──────────────────────────────────────────────────────────────
+
+INGRESS_MODE="${INGRESS_MODE:-route}"
+DISCONNECTED="${DISCONNECTED:-false}"
+CLUSTER_DOMAIN="${CLUSTER_DOMAIN:-}"
+CERT_NAME="${CERT_NAME:-}"
+DRY_RUN="${DRY_RUN:-false}"
+MAAS_MANIFEST_REF="${MAAS_MANIFEST_REF:-}"
+
+# Constants
+GATEWAY_NAMESPACE="openshift-ingress"
+GATEWAY_NAME="maas-default-gateway"
+GATEWAYCLASS_NAME="openshift-default"
+GW_OPTIONS_CONFIGMAP="gw-options"
+GATEWAY_ROUTE_NAME="maas-gateway-route"
+SERVICE_CA_SECRET="maas-gw-service-tls"
+
+# Gateway Service name follows the pattern: <gateway-name>-<gatewayclass-name>
+GATEWAY_SERVICE_NAME="${GATEWAY_NAME}-${GATEWAYCLASS_NAME}"
+
+# Timeout for Gateway Programmed condition (seconds)
+GATEWAY_TIMEOUT="${CUSTOM_CHECK_TIMEOUT:-120}"
+
+#──────────────────────────────────────────────────────────────
+# VALIDATION
+#──────────────────────────────────────────────────────────────
+
+validate_configuration() {
+  log_info "Validating gateway configuration..."
+
+  # Validate ingress mode
+  if [[ ! "$INGRESS_MODE" =~ ^(route|clusterip)$ ]]; then
+    log_error "Invalid INGRESS_MODE: $INGRESS_MODE"
+    log_error "Must be 'route' or 'clusterip'"
+    exit 1
+  fi
+
+  # Validate required tools
+  local missing=()
+  command -v kubectl &>/dev/null || missing+=("kubectl")
+  if [[ "$INGRESS_MODE" == "route" ]]; then
+    command -v kustomize &>/dev/null || missing+=("kustomize")
+    command -v envsubst &>/dev/null || missing+=("envsubst")
+  fi
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log_error "Missing required tools:"
+    for tool in "${missing[@]}"; do
+      log_error "  - $tool"
+    done
+    exit 1
+  fi
+
+  log_info "Configuration validated"
+  log_info "  Ingress mode: $INGRESS_MODE"
+  log_info "  Disconnected: $DISCONNECTED"
+}
+
+#──────────────────────────────────────────────────────────────
+# CLUSTER DOMAIN DETECTION
+#──────────────────────────────────────────────────────────────
+
+detect_cluster_domain() {
+  if [[ -n "$CLUSTER_DOMAIN" ]]; then
+    log_info "Using provided cluster domain: $CLUSTER_DOMAIN"
+    return 0
+  fi
+
+  log_info "Detecting cluster domain..."
+  CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "")
+
+  if [[ -z "$CLUSTER_DOMAIN" ]]; then
+    log_error "Could not determine cluster domain"
+    log_error "Set CLUSTER_DOMAIN environment variable manually"
+    exit 1
+  fi
+
+  log_info "  Detected cluster domain: $CLUSTER_DOMAIN"
+}
+
+# Resolve immutable git ref for remote kustomize fallback (route mode only).
+resolve_maas_manifest_ref() {
+  if [[ -n "$MAAS_MANIFEST_REF" ]]; then
+    echo "$MAAS_MANIFEST_REF"
+    return 0
+  fi
+
+  local project_root
+  if project_root="$(find_project_root 2>/dev/null)"; then
+    local sha
+    sha=$(git -C "$project_root" rev-parse HEAD 2>/dev/null || echo "")
+    if [[ -n "$sha" ]]; then
+      echo "$sha"
+      return 0
+    fi
+  fi
+
+  log_error "MAAS_MANIFEST_REF is not set and could not resolve from local git repository"
+  log_error "Set MAAS_MANIFEST_REF to a release tag or commit SHA, use a full repo clone, or set DISCONNECTED=true"
+  exit 1
+}
+
+#──────────────────────────────────────────────────────────────
+# TLS CERTIFICATE DETECTION (route mode only)
+#──────────────────────────────────────────────────────────────
+
+detect_tls_certificate() {
+  if [[ -n "$CERT_NAME" ]]; then
+    log_info "Using provided TLS certificate: $CERT_NAME"
+    return 0
+  fi
+
+  log_info "Detecting TLS certificate secret..."
+
+  # Primary: Get certificate from IngressController (most reliable source)
+  CERT_NAME=$(kubectl get ingresscontroller default -n openshift-ingress-operator \
+    -o jsonpath='{.spec.defaultCertificate.name}' 2>/dev/null || echo "")
+
+  if [[ -n "$CERT_NAME" ]] && kubectl get secret -n "$GATEWAY_NAMESPACE" "$CERT_NAME" &>/dev/null; then
+    log_info "  Found certificate from IngressController: $CERT_NAME"
+    return 0
+  fi
+
+  [[ -n "$CERT_NAME" ]] && log_debug "  IngressController cert '$CERT_NAME' not found, trying alternatives..."
+  CERT_NAME=""
+
+  # Fallback 1: Get certificate from router deployment
+  CERT_NAME=$(kubectl get deployment router-default -n "$GATEWAY_NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.volumes[?(@.name=="default-certificate")].secret.secretName}' 2>/dev/null || echo "")
+
+  if [[ -n "$CERT_NAME" ]] && kubectl get secret -n "$GATEWAY_NAMESPACE" "$CERT_NAME" &>/dev/null; then
+    log_info "  Found certificate from router deployment: $CERT_NAME"
+    return 0
+  fi
+  CERT_NAME=""
+
+  # Fallback 2: Check known certificate secret names
+  local cert_candidates=("default-gateway-cert" "router-certs-default")
+  for cert in "${cert_candidates[@]}"; do
+    if kubectl get secret -n "$GATEWAY_NAMESPACE" "$cert" &>/dev/null; then
+      CERT_NAME="$cert"
+      log_info "  Found TLS certificate secret: $CERT_NAME"
+      return 0
+    fi
+  done
+
+  # Final fallback: Create self-signed certificate
+  log_warn "  No TLS certificate found. Creating self-signed certificate..."
+  local gateway_hostname="maas.${CLUSTER_DOMAIN}"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    CERT_NAME="maas-gateway-tls"
+    log_info "  [DRY RUN] Would create self-signed certificate: $CERT_NAME"
+    return 0
+  fi
+  if create_tls_secret "maas-gateway-tls" "$GATEWAY_NAMESPACE" "${gateway_hostname}"; then
+    CERT_NAME="maas-gateway-tls"
+    log_info "  Created self-signed certificate: $CERT_NAME"
+  else
+    log_error "Failed to create TLS certificate for gateway"
+    exit 1
+  fi
+}
+
+#──────────────────────────────────────────────────────────────
+# GATEWAYCLASS SETUP
+#──────────────────────────────────────────────────────────────
+
+setup_gatewayclass() {
+  log_info "Setting up GatewayClass..."
+
+  # Note: Create-only; does not update existing GatewayClass.
+  # Delete the GatewayClass to recreate if spec changes.
+  if kubectl get gatewayclass "$GATEWAYCLASS_NAME" &>/dev/null; then
+    log_info "  GatewayClass $GATEWAYCLASS_NAME already exists"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "  [DRY RUN] Would create GatewayClass $GATEWAYCLASS_NAME"
+    return 0
+  fi
+
+  log_info "  Creating GatewayClass $GATEWAYCLASS_NAME..."
+
+  kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ${GATEWAYCLASS_NAME}
+spec:
+  controllerName: "openshift.io/gateway-controller/v1"
+EOF
+}
+
+#──────────────────────────────────────────────────────────────
+# ROUTE MODE SETUP
+#──────────────────────────────────────────────────────────────
+
+setup_route_mode() {
+  log_info "Setting up Gateway in route mode..."
+
+  detect_tls_certificate
+
+  # Check if Gateway already exists and is Programmed
+  if kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" &>/dev/null; then
+    log_info "  Gateway $GATEWAY_NAME already exists in $GATEWAY_NAMESPACE"
+
+    if kubectl wait --for=condition=Programmed gateway/"$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" --timeout=10s &>/dev/null; then
+      # Verify required annotations are present before skipping update
+      local managed_anno authorino_anno params_ref
+      managed_anno=$(kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" \
+        -o jsonpath='{.metadata.annotations.opendatahub\.io/managed}' 2>/dev/null || echo "")
+      authorino_anno=$(kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" \
+        -o jsonpath='{.metadata.annotations.security\.opendatahub\.io/authorino-tls-bootstrap}' 2>/dev/null || echo "")
+      # Route mode should NOT have infrastructure.parametersRef (clusterip mode does)
+      params_ref=$(kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" \
+        -o jsonpath='{.spec.infrastructure.parametersRef.name}' 2>/dev/null || echo "")
+
+      if [[ "$managed_anno" == "false" ]] && [[ "$authorino_anno" == "true" ]] && [[ -z "$params_ref" ]]; then
+        log_info "  Gateway is Programmed with required annotations and route mode spec"
+        return 0
+      else
+        if [[ -n "$params_ref" ]]; then
+          log_info "  Gateway has parametersRef ($params_ref) - recreating for route mode..."
+        else
+          log_info "  Gateway is missing required annotations, updating..."
+        fi
+      fi
+    else
+      log_info "  Updating Gateway configuration..."
+    fi
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "  [DRY RUN] Would create/update Gateway $GATEWAY_NAME"
+    log_info "    Cluster domain: $CLUSTER_DOMAIN"
+    log_info "    TLS certificate: $CERT_NAME"
+    return 0
+  fi
+
+  log_info "  Creating/updating Gateway $GATEWAY_NAME..."
+  log_info "    Cluster domain: $CLUSTER_DOMAIN"
+  log_info "    TLS certificate: $CERT_NAME"
+
+  # Determine manifest location
+  local project_root
+  project_root="$(find_project_root)" || {
+    log_error "Could not determine project root"
+    exit 1
+  }
+
+  local maas_networking_dir="$project_root/deployment/base/networking/maas"
+
+  # Apply Gateway manifest with variable substitution
+  if [[ -d "$maas_networking_dir" ]]; then
+    log_debug "  Using local manifest: $maas_networking_dir"
+    kustomize build "$maas_networking_dir" | \
+      CLUSTER_DOMAIN="$CLUSTER_DOMAIN" CERT_NAME="$CERT_NAME" envsubst '$CLUSTER_DOMAIN $CERT_NAME' | \
+      kubectl apply --server-side=true -f -
+  elif [[ "$DISCONNECTED" == "true" ]]; then
+    log_error "DISCONNECTED=true but local manifest not found: $maas_networking_dir"
+    exit 1
+  else
+    # Fallback: fetch from GitHub (pinned ref, not mutable main)
+    local manifest_ref
+    manifest_ref="$(resolve_maas_manifest_ref)"
+    log_debug "  Local manifest not found, fetching from GitHub (ref=${manifest_ref})..."
+    kustomize build "https://github.com/opendatahub-io/models-as-a-service.git/deployment/base/networking/maas?ref=${manifest_ref}" | \
+      CLUSTER_DOMAIN="$CLUSTER_DOMAIN" CERT_NAME="$CERT_NAME" envsubst '$CLUSTER_DOMAIN $CERT_NAME' | \
+      kubectl apply --server-side=true -f -
+  fi
+
+  # Wait for Gateway to be Programmed
+  # Note: In route mode, we warn but don't exit if the Gateway is not Programmed.
+  # The Gateway resource is created successfully, and it may take longer on some
+  # clusters (e.g., Service Mesh not fully ready). This is a soft check.
+  # In clusterip mode, we exit 1 because the Gateway MUST be Programmed before
+  # the Route can be created in the next step (see wait_gateway_programmed).
+  log_info "  Waiting for Gateway to be Programmed (timeout: ${GATEWAY_TIMEOUT}s)..."
+  if ! kubectl wait --for=condition=Programmed gateway/"$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" --timeout="${GATEWAY_TIMEOUT}s" 2>/dev/null; then
+    log_warn "Gateway not Programmed after ${GATEWAY_TIMEOUT}s - check Service Mesh installation"
+  else
+    log_info "  Gateway is Programmed"
+  fi
+}
+
+#──────────────────────────────────────────────────────────────
+# CLUSTERIP MODE SETUP
+#──────────────────────────────────────────────────────────────
+
+setup_clusterip_mode() {
+  log_info "Setting up Gateway in clusterip mode (with OpenShift Route)..."
+
+  # Step 1: Create ConfigMap/gw-options
+  create_gw_options_configmap
+
+  # Step 2: Create Gateway with infrastructure.parametersRef
+  create_clusterip_gateway
+
+  # Step 3: Wait for Gateway to be Programmed (required before Route can work)
+  wait_gateway_programmed
+
+  # Step 4: Create OpenShift Route
+  create_gateway_route
+
+  log_info "ClusterIP mode setup complete"
+}
+
+create_gw_options_configmap() {
+  # Note: Create-only; does not update existing ConfigMap content.
+  # Same behavior as GatewayClass setup. Delete the ConfigMap to recreate.
+  if kubectl get configmap "$GW_OPTIONS_CONFIGMAP" -n "$GATEWAY_NAMESPACE" &>/dev/null; then
+    log_info "  ConfigMap $GW_OPTIONS_CONFIGMAP already exists"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "  [DRY RUN] Would create ConfigMap $GW_OPTIONS_CONFIGMAP"
+    return 0
+  fi
+
+  log_info "  Creating ConfigMap $GW_OPTIONS_CONFIGMAP..."
+
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${GW_OPTIONS_CONFIGMAP}
+  namespace: ${GATEWAY_NAMESPACE}
+data:
+  service: |
+    metadata:
+      annotations:
+        # OpenShift service-ca-operator auto-provisions a TLS certificate into this Secret.
+        # The Secret name here MUST match the certificateRefs in the Gateway listener.
+        service.beta.openshift.io/serving-cert-secret-name: "${SERVICE_CA_SECRET}"
+    spec:
+      # ClusterIP avoids provisioning an external LoadBalancer; the OpenShift Route
+      # handles external ingress instead.
+      type: ClusterIP
+EOF
+}
+
+create_clusterip_gateway() {
+  # Check if Gateway already exists and is Programmed
+  if kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" &>/dev/null; then
+    log_info "  Gateway $GATEWAY_NAME already exists in $GATEWAY_NAMESPACE"
+
+    if kubectl wait --for=condition=Programmed gateway/"$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" --timeout=10s &>/dev/null; then
+      # Verify required annotations AND spec match clusterip mode before skipping update
+      local managed_anno authorino_anno params_ref
+      managed_anno=$(kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" \
+        -o jsonpath='{.metadata.annotations.opendatahub\.io/managed}' 2>/dev/null || echo "")
+      authorino_anno=$(kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" \
+        -o jsonpath='{.metadata.annotations.security\.opendatahub\.io/authorino-tls-bootstrap}' 2>/dev/null || echo "")
+      # ClusterIP mode MUST have infrastructure.parametersRef pointing to gw-options ConfigMap
+      params_ref=$(kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" \
+        -o jsonpath='{.spec.infrastructure.parametersRef.name}' 2>/dev/null || echo "")
+
+      if [[ "$managed_anno" == "false" ]] && [[ "$authorino_anno" == "true" ]] && [[ "$params_ref" == "$GW_OPTIONS_CONFIGMAP" ]]; then
+        log_info "  Gateway is Programmed with required annotations and clusterip mode spec"
+        return 0
+      else
+        if [[ "$params_ref" != "$GW_OPTIONS_CONFIGMAP" ]]; then
+          log_info "  Gateway spec doesn't match clusterip mode (parametersRef: '$params_ref' != '$GW_OPTIONS_CONFIGMAP') - recreating..."
+        else
+          log_info "  Gateway is missing required annotations, updating..."
+        fi
+      fi
+    else
+      log_info "  Updating Gateway configuration..."
+    fi
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "  [DRY RUN] Would create/update Gateway $GATEWAY_NAME (clusterip mode)"
+    return 0
+  fi
+
+  log_info "  Creating/updating Gateway $GATEWAY_NAME (clusterip mode)..."
+
+  kubectl apply --server-side=true -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${GATEWAY_NAME}
+  namespace: ${GATEWAY_NAMESPACE}
+  labels:
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/instance: ${GATEWAY_NAME}
+    app.kubernetes.io/component: gateway
+    opendatahub.io/managed: "false"
+  annotations:
+    opendatahub.io/managed: "false"
+    security.opendatahub.io/authorino-tls-bootstrap: "true"
+spec:
+  gatewayClassName: ${GATEWAYCLASS_NAME}
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: ${GW_OPTIONS_CONFIGMAP}
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            # Must match the serving-cert-secret-name in gw-options ConfigMap.
+            # service-ca-operator populates this Secret automatically.
+            name: ${SERVICE_CA_SECRET}
+        mode: Terminate
+EOF
+}
+
+wait_gateway_programmed() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "  [DRY RUN] Would wait for Gateway to be Programmed"
+    return 0
+  fi
+
+  log_info "  Waiting for Gateway to be Programmed (timeout: ${GATEWAY_TIMEOUT}s)..."
+  if ! kubectl wait --for=condition=Programmed gateway/"$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" --timeout="${GATEWAY_TIMEOUT}s" 2>/dev/null; then
+    log_error "Gateway not Programmed after ${GATEWAY_TIMEOUT}s"
+    log_error "Check Gateway status: kubectl get gateway $GATEWAY_NAME -n $GATEWAY_NAMESPACE -o yaml"
+    exit 1
+  fi
+
+  log_info "  Gateway is Programmed"
+
+  # Verify Gateway Service was created by controller
+  if ! kubectl get svc "$GATEWAY_SERVICE_NAME" -n "$GATEWAY_NAMESPACE" &>/dev/null; then
+    log_error "Gateway Service $GATEWAY_SERVICE_NAME not found"
+    log_error "Expected Service name: $GATEWAY_SERVICE_NAME"
+    log_error "Check available services: kubectl get svc -n $GATEWAY_NAMESPACE"
+    exit 1
+  fi
+
+  log_info "  Gateway Service ready: $GATEWAY_SERVICE_NAME"
+}
+
+create_gateway_route() {
+  if kubectl get route "$GATEWAY_ROUTE_NAME" -n "$GATEWAY_NAMESPACE" &>/dev/null; then
+    local route_admitted
+    route_admitted=$(kubectl get route "$GATEWAY_ROUTE_NAME" -n "$GATEWAY_NAMESPACE" \
+      -o jsonpath='{.status.ingress[0].conditions[?(@.type=="Admitted")].status}' 2>/dev/null || echo "")
+
+    if [[ "$route_admitted" == "True" ]]; then
+      log_info "  Route $GATEWAY_ROUTE_NAME already exists and is Admitted"
+      return 0
+    fi
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "  [DRY RUN] Would create Route $GATEWAY_ROUTE_NAME"
+    log_info "    Host: maas.$CLUSTER_DOMAIN"
+    log_info "    Target Service: $GATEWAY_SERVICE_NAME"
+    return 0
+  fi
+
+  log_info "  Creating Route $GATEWAY_ROUTE_NAME..."
+  log_info "    Host: maas.$CLUSTER_DOMAIN"
+  log_info "    Target Service: $GATEWAY_SERVICE_NAME"
+
+  # Fetch the service CA bundle so the router can verify the backend certificate
+  local service_ca_bundle
+  service_ca_bundle=$(kubectl get configmap signing-cabundle -n openshift-service-ca \
+    -o jsonpath='{.data.ca-bundle\.crt}' 2>/dev/null || echo "")
+
+  if [[ -z "$service_ca_bundle" ]]; then
+    log_error "Failed to retrieve service CA bundle from openshift-service-ca/signing-cabundle"
+    log_error "The Route reencrypt termination requires this CA to verify the backend certificate"
+    exit 1
+  fi
+
+  kubectl apply -f - <<EOF
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ${GATEWAY_ROUTE_NAME}
+  namespace: ${GATEWAY_NAMESPACE}
+spec:
+  host: maas.${CLUSTER_DOMAIN}
+  to:
+    kind: Service
+    # The Gateway controller creates a Service whose name is derived from the
+    # Gateway name and GatewayClass name.
+    name: ${GATEWAY_SERVICE_NAME}
+    weight: 100
+  port:
+    targetPort: 443
+  tls:
+    # Re-encrypt: the Router terminates the client TLS session and opens a new
+    # TLS connection to the Gateway Service using the service-ca certificate.
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+    # Provide the service CA bundle so the router can verify the backend certificate.
+    # Without this, reencrypt handshake will fail on clusters where the router
+    # doesn't implicitly trust service-ca (e.g., bare-metal, disconnected).
+    destinationCACertificate: |
+$(echo "$service_ca_bundle" | sed 's/^/      /')
+EOF
+
+  # Wait briefly for Route to be Admitted
+  log_info "  Waiting for Route to be Admitted..."
+  local wait_time=0
+  local max_wait=30
+  while [[ $wait_time -lt $max_wait ]]; do
+    local route_admitted
+    route_admitted=$(kubectl get route "$GATEWAY_ROUTE_NAME" -n "$GATEWAY_NAMESPACE" \
+      -o jsonpath='{.status.ingress[0].conditions[?(@.type=="Admitted")].status}' 2>/dev/null || echo "")
+
+    if [[ "$route_admitted" == "True" ]]; then
+      log_info "  Route is Admitted"
+      return 0
+    fi
+
+    sleep 2
+    wait_time=$((wait_time + 2))
+  done
+
+  log_warn "Route not Admitted after ${max_wait}s - check Route status manually"
+}
+
+#──────────────────────────────────────────────────────────────
+# MAIN ENTRY POINT
+#──────────────────────────────────────────────────────────────
+
+main() {
+  log_info "==================================================="
+  log_info "  MaaS Gateway Setup"
+  log_info "==================================================="
+
+  validate_configuration
+  detect_cluster_domain
+
+  # Setup GatewayClass (required for both modes)
+  setup_gatewayclass
+
+  # Mode-specific setup
+  case "$INGRESS_MODE" in
+    route)
+      setup_route_mode
+      ;;
+    clusterip)
+      setup_clusterip_mode
+      ;;
+  esac
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_info ""
+    log_info "DRY RUN MODE - no changes were applied"
+  fi
+
+  log_info ""
+  log_info "==================================================="
+  log_info "  Gateway setup completed successfully"
+  log_info "==================================================="
+  log_info "  Mode: $INGRESS_MODE"
+  log_info "  Gateway: $GATEWAY_NAME"
+  log_info "  Namespace: $GATEWAY_NAMESPACE"
+
+  if [[ "$INGRESS_MODE" == "clusterip" ]]; then
+    log_info "  Route: $GATEWAY_ROUTE_NAME"
+    log_info "  Hostname: maas.$CLUSTER_DOMAIN"
+  fi
+
+  log_info ""
+  log_info "Verify with:"
+  log_info "  kubectl get gateway $GATEWAY_NAME -n $GATEWAY_NAMESPACE"
+
+  if [[ "$INGRESS_MODE" == "clusterip" ]]; then
+    log_info "  kubectl get route $GATEWAY_ROUTE_NAME -n $GATEWAY_NAMESPACE"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Cherry-pick of https://github.com/red-hat-data-services/models-as-a-service/commit/a24c8c835dce6ca9cdb728fa7d360e07c924cb89 from main to rhoai-3.4.

## Summary
- Adds standalone `scripts/setup-gateway.sh` script for `maas-default-gateway` setup
- Supports two deployment modes: route (LoadBalancer) and clusterip (ClusterIP + Route)
- Implements TLS auto-detection with four-level fallback
- Fixes Route reencrypt termination with proper `destinationCACertificate` configuration
- Updates documentation in `scripts/README.md` and `docs/content/install/maas-setup.md`

## Changes
- **scripts/setup-gateway.sh** (NEW): Standalone gateway setup script with route and clusterip modes
- **scripts/deploy.sh**: Replaced inline gateway logic with call to setup-gateway.sh
- **scripts/README.md**: Added documentation for setup-gateway.sh
- **docs/content/install/maas-setup.md**: Updated Create Gateway section to reference script

## Risk analysis
**Risk rating**: 2

**Why**: This is a cherry-pick of tested changes from main. The commit has already been validated in the upstream and downstream main branches. The changes extract existing functionality into a standalone script without altering core behavior, making it low-medium risk for the stable release branch.

## Test plan
- [ ] Verify gateway setup on ROSA cluster (route mode)
- [ ] Verify gateway setup on disconnected cluster (clusterip mode)
- [ ] Validate TLS auto-detection fallback chain
- [ ] Confirm Route reencrypt termination works correctly

---

🤖 Generated by Claude Code