### PR TITLE
fix: cherry-pick #1040 - update ipp config format and image to match llm-d framework

### DIFF
--- a/.github/scripts/update-payload-processing.sh
+++ b/.github/scripts/update-payload-processing.sh
@@ -51,7 +51,7 @@ fi
 
 LOCAL_DEPLOY="${PROJECT_ROOT}/test/e2e/scripts/local-deploy.sh"
 if [ -f "$LOCAL_DEPLOY" ]; then
-    sed -i "s#BBR_IMAGE=\"\${BBR_IMAGE:-quay.io/opendatahub/odh-ai-gateway-payload-processing:.*}\"#BBR_IMAGE=\"\${BBR_IMAGE:-${IMAGE}}\"#" "$LOCAL_DEPLOY"
+    sed -i "s#IPP_IMAGE=\"\${IPP_IMAGE:-quay.io/opendatahub/odh-ai-gateway-payload-processing:.*}\"#IPP_IMAGE=\"\${IPP_IMAGE:-${IMAGE}}\"#" "$LOCAL_DEPLOY"
     echo "  - test/e2e/scripts/local-deploy.sh"
 fi
 

--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
@@ -75,7 +75,7 @@ spec:
                 description: |-
                   Endpoint is the FQDN of the external provider (no scheme or path).
                   e.g. "api.openai.com".
-                  This field is metadata for downstream consumers (e.g. BBR provider-resolver plugin)
+                  This field is metadata for downstream consumers (e.g. IPP provider-resolver plugin)
                   and is not used by the controller for endpoint derivation.
                 maxLength: 253
                 minLength: 1

--- a/deployment/base/maas-controller/default/params.env
+++ b/deployment/base/maas-controller/default/params.env
@@ -1,4 +1,4 @@
 maas-api-image=quay.io/opendatahub/maas-api:latest
 maas-controller-image=quay.io/opendatahub/maas-controller:latest
-payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:ed049f48739fc4c52f30080c4337073595fd95b6
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7

--- a/deployment/base/payload-processing/instance/deployment.yaml
+++ b/deployment/base/payload-processing/instance/deployment.yaml
@@ -27,39 +27,10 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
           args:
-            - "--streaming"
-            - --v
-            - "3"
-            - --plugin
-            - "$(MODEL_TO_HEADER)"
-            - --plugin
-            - "$(MODEL_PROVIDER_RESOLVER)"
-            - --plugin
-            - "$(API_TRANSLATION)"
-            - --plugin
-            - "$(APIKEY_INJECTION)"
+            - --config-file
+            - "/config/custom-ipp-config.yaml"
+            - --v=3
             - --tracing=false
-          env:
-            - name: MODEL_TO_HEADER
-              valueFrom:
-                configMapKeyRef:
-                  name: payload-processing-plugins
-                  key: model-to-header-plugin
-            - name: MODEL_PROVIDER_RESOLVER
-              valueFrom:
-                configMapKeyRef:
-                  name: payload-processing-plugins
-                  key: model-provider-resolver-plugin
-            - name: API_TRANSLATION
-              valueFrom:
-                configMapKeyRef:
-                  name: payload-processing-plugins
-                  key: api-translation-plugin
-            - name: APIKEY_INJECTION
-              valueFrom:
-                configMapKeyRef:
-                  name: payload-processing-plugins
-                  key: apikey-injection-plugin
           ports:
             - containerPort: 9004
               name: grpc
@@ -84,3 +55,10 @@ spec:
               port: grpc
             initialDelaySeconds: 5
             periodSeconds: 10
+          volumeMounts:
+            - name: plugins-config-volume
+              mountPath: "/config"
+      volumes:
+        - name: plugins-config-volume
+          configMap:
+            name: payload-processing-plugins

--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -22,7 +22,7 @@ spec:
       patch:
         operation: INSERT_BEFORE
         value:
-          name: envoy.filters.http.ext_proc.bbr-pre
+          name: envoy.filters.http.ext_proc.ipp-pre
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
             failure_mode_allow: true
@@ -49,7 +49,7 @@ spec:
       patch:
         operation: INSERT_AFTER
         value:
-          name: envoy.filters.http.ext_proc.bbr
+          name: envoy.filters.http.ext_proc.ipp
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
             failure_mode_allow: false
@@ -77,7 +77,7 @@ spec:
         operation: MERGE
         value:
           typed_per_filter_config:
-            envoy.filters.http.ext_proc.bbr-pre:
+            envoy.filters.http.ext_proc.ipp-pre:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
               disabled: true
     # Disable ext_proc on non-inference routes (maas-api /maas-api/*).
@@ -92,6 +92,6 @@ spec:
         operation: MERGE
         value:
           typed_per_filter_config:
-            envoy.filters.http.ext_proc.bbr-pre:
+            envoy.filters.http.ext_proc.ipp-pre:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
               disabled: true

--- a/deployment/base/payload-processing/manager/kustomization.yaml
+++ b/deployment/base/payload-processing/manager/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
   - name: payload-processing
     newName: quay.io/opendatahub/odh-ai-gateway-payload-processing
-    newTag: ed049f48739fc4c52f30080c4337073595fd95b6
+    newTag: odh-stable

--- a/deployment/base/payload-processing/manager/plugins-configmap.yaml
+++ b/deployment/base/payload-processing/manager/plugins-configmap.yaml
@@ -4,10 +4,33 @@ metadata:
   name: payload-processing-plugins
   namespace: openshift-ingress
 data:
-  # Each key defines a plugin passed as --plugin <value> to the BBR ext_proc server.
-  # Format: "<plugin-type>:<plugin-name>[:<json-config>]"
-  # Overlays can add/remove plugins by patching this ConfigMap.
-  model-to-header-plugin: "body-field-to-header:model-extractor:{\"fieldName\":\"model\",\"headerName\":\"X-Gateway-Model-Name\"}"
-  model-provider-resolver-plugin: "model-provider-resolver:model-provider-resolver"
-  api-translation-plugin: "api-translation:api-translation"
-  apikey-injection-plugin: "apikey-injection:apikey-injection"
+  custom-pre-processing-ipp-config.yaml: |
+    apiVersion: llm-d.ai/v1alpha1
+    kind: PayloadProcessorConfig
+    plugins:
+    - type: body-field-to-header
+      name: model-extractor
+      parameters:
+        fieldName: model
+        headerName: X-Gateway-Model-Name
+    profiles:
+    - name: default
+      plugins:
+        request:
+        - pluginRef: model-extractor
+  custom-ipp-config.yaml: |
+    apiVersion: llm-d.ai/v1alpha1
+    kind: PayloadProcessorConfig
+    plugins:
+    - type: model-provider-resolver
+    - type: api-translation
+    - type: apikey-injection
+    profiles:
+    - name: default
+      plugins:
+        request:
+        - pluginRef: model-provider-resolver
+        - pluginRef: api-translation
+        - pluginRef: apikey-injection
+        response:
+        - pluginRef: api-translation

--- a/deployment/base/payload-processing/pre-processing/deployment-patch.yaml
+++ b/deployment/base/payload-processing/pre-processing/deployment-patch.yaml
@@ -13,20 +13,10 @@
 - op: replace
   path: /spec/template/spec/containers/0/args
   value:
-    - "--streaming"
-    - --v
-    - "3"
-    - --plugin
-    - "$(MODEL_TO_HEADER)"
-    - --tracing=false
-- op: replace
-  path: /spec/template/spec/containers/0/env
-  value:
-    - name: MODEL_TO_HEADER
-      valueFrom:
-        configMapKeyRef:
-          name: payload-processing-plugins
-          key: model-to-header-plugin
+  - --config-file
+  - "/config/custom-pre-processing-ipp-config.yaml"
+  - --v=3
+  - --tracing=false
 - op: replace
   path: /spec/template/spec/containers/0/ports
   value:

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -1,6 +1,6 @@
 maas-api-image=quay.io/opendatahub/maas-api:odh-stable
 maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
-payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:ed049f48739fc4c52f30080c4337073595fd95b6
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
 payload-processing-replicas=1
 gateway-namespace=openshift-ingress

--- a/docs/content/install/external-model-setup.md
+++ b/docs/content/install/external-model-setup.md
@@ -86,7 +86,7 @@ Store the external provider's API key in a Kubernetes Secret. The Secret must:
 
 - Be in the same namespace as the ExternalModel
 - Use the data key `api-key`
-- Have the label `inference.networking.k8s.io/bbr-managed=true` so IPP can read it
+- Have the label `inference.llm-d.ai/ipp-managed=true` so IPP can read it
 
 ```bash
 TMP_KEY_FILE="$(mktemp)"
@@ -98,7 +98,7 @@ kubectl create secret generic openai-api-key -n llm \
 
 rm -f "${TMP_KEY_FILE}"
 
-kubectl label secret openai-api-key -n llm inference.networking.k8s.io/bbr-managed=true
+kubectl label secret openai-api-key -n llm inference.llm-d.ai/ipp-managed=true
 ```
 
 ## Step 4: Create the ExternalModel and MaaSModelRef

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -188,7 +188,7 @@ func (m *Manager) FilterModelsByAccess(ctx context.Context, models []Model, auth
 	for i := range models {
 		model := models[i]
 		// External models cannot be probed — their /v1/models endpoint requires
-		// the provider API key (injected by BBR), not the user's MaaS token.
+		// the provider API key (injected by IPP), not the user's MaaS token.
 		// Include them directly if they are Ready; access is enforced by the
 		// gateway auth policy at inference time.
 		if model.Kind == "ExternalModel" {

--- a/maas-controller/api/maas/v1alpha1/externalmodel_types.go
+++ b/maas-controller/api/maas/v1alpha1/externalmodel_types.go
@@ -56,7 +56,7 @@ type ExternalModelSpec struct {
 
 	// Endpoint is the FQDN of the external provider (no scheme or path).
 	// e.g. "api.openai.com".
-	// This field is metadata for downstream consumers (e.g. BBR provider-resolver plugin)
+	// This field is metadata for downstream consumers (e.g. IPP provider-resolver plugin)
 	// and is not used by the controller for endpoint derivation.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -178,7 +178,7 @@ func (h *externalModelHandler) Status(ctx context.Context, log logr.Logger, mode
 
 // GetModelEndpoint returns the endpoint URL for the ExternalModel.
 // Uses ExternalModel name (spec.modelRef.name) in the path to match the HTTPRoute
-// created by the reconciler and BBR's model-provider-resolver store key.
+// created by the reconciler and IPP's model-provider-resolver store key.
 func (h *externalModelHandler) GetModelEndpoint(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) (string, error) {
 	extModelName := model.Spec.ModelRef.Name
 	if len(model.Status.HTTPRouteHostnames) > 0 {

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -60,7 +60,7 @@ const (
 	DefaultMaaSAPINamespace = "opendatahub"
 
 	DefaultMaaSAPIImage            = "quay.io/opendatahub/maas-api:latest"
-	DefaultPayloadProcessingImage  = "quay.io/opendatahub/odh-ai-gateway-payload-processing:ed049f48739fc4c52f30080c4337073595fd95b6"
+	DefaultPayloadProcessingImage  = "quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable"
 	DefaultMaaSAPIKeyCleanupImage  = "registry.redhat.io/ubi9/ubi-minimal:9.7"
 	DefaultAPIKeyMaxExpirationDays = "90"
 

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -204,10 +204,10 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		wantRouteName := fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName(params.TenantIdentifier), i-2)
 		assert.Equal(t, wantRouteName, routeName, "configPatches[%d] route name", i)
 
-		disabled, found, err := unstructured.NestedBool(cp, "patch", "value", "typed_per_filter_config", "envoy.filters.http.ext_proc.bbr-pre", "disabled")
-		require.NoError(t, err, "configPatches[%d] bbr-pre disabled field", i)
-		require.True(t, found, "configPatches[%d] bbr-pre disabled field should exist", i)
-		assert.True(t, disabled, "configPatches[%d] bbr-pre should be disabled", i)
+		disabled, found, err := unstructured.NestedBool(cp, "patch", "value", "typed_per_filter_config", "envoy.filters.http.ext_proc.ipp-pre", "disabled")
+		require.NoError(t, err, "configPatches[%d] ipp-pre disabled field", i)
+		require.True(t, found, "configPatches[%d] ipp-pre disabled field should exist", i)
+		assert.True(t, disabled, "configPatches[%d] ipp-pre should be disabled", i)
 	}
 
 	// Verify payload-pre-processing Deployment and Service are present and namespaced correctly.

--- a/maas-controller/pkg/reconciler/externalmodel/resources.go
+++ b/maas-controller/pkg/reconciler/externalmodel/resources.go
@@ -86,7 +86,7 @@ func buildDestinationRule(endpoint, name, namespace string, labels map[string]st
 // buildHTTPRoute creates the HTTPRoute in the model's namespace.
 // Path prefix is /<namespace>/<name> for namespace isolation.
 // Only a Host header filter is set (required for TLS SNI).
-// BBR ext-proc handles path rewriting and provider-specific headers.
+// IPP ext-proc handles path rewriting and provider-specific headers.
 func buildHTTPRoute(endpoint, name, targetModel, namespace string, port int32, gatewayName, gatewayNamespace string, labels map[string]string) *gatewayapiv1.HTTPRoute {
 	gwNamespace := gatewayapiv1.Namespace(gatewayNamespace)
 	pathType := gatewayapiv1.PathMatchPathPrefix
@@ -107,7 +107,7 @@ func buildHTTPRoute(endpoint, name, targetModel, namespace string, port int32, g
 	}
 
 	// Host header is required for TLS SNI — must be set before TLS handshake,
-	// which happens before BBR ext-proc runs.
+	// which happens before IPP ext-proc runs.
 	filters := []gatewayapiv1.HTTPRouteFilter{
 		{
 			Type: gatewayapiv1.HTTPRouteFilterRequestHeaderModifier,
@@ -152,7 +152,7 @@ func buildHTTPRoute(endpoint, name, targetModel, namespace string, port int32, g
 					Filters:     filters,
 					Timeouts:    &gatewayapiv1.HTTPRouteTimeouts{Request: &timeout},
 				},
-				// Rule 2: Header-based match — BBR ClearRouteCache sets this header
+				// Rule 2: Header-based match — IPP ClearRouteCache sets this header
 				{
 					Matches: []gatewayapiv1.HTTPRouteMatch{
 						{

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -549,7 +549,7 @@ main() {
     [[ "${DEV_MODE:-false}" == "true" ]] && default_tag="latest"
     local cm_maas_api_image="${MAAS_API_IMAGE:-quay.io/opendatahub/maas-api:${default_tag}}"
     local cm_maas_controller_image="${MAAS_CONTROLLER_IMAGE:-quay.io/opendatahub/maas-controller:${default_tag}}"
-    local cm_payload_processing_image="${PAYLOAD_PROCESSING_IMAGE:-$(get_odh_overlay_param payload-processing-image 2>/dev/null || echo "quay.io/opendatahub/odh-ai-gateway-payload-processing:ed049f48739fc4c52f30080c4337073595fd95b6")}"
+    local cm_payload_processing_image="${PAYLOAD_PROCESSING_IMAGE:-$(get_odh_overlay_param payload-processing-image 2>/dev/null || echo "quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable")}"
     local cm_cleanup_image="registry.redhat.io/ubi9/ubi-minimal:9.7"
 
     log_info "  Ensuring maas-parameters ConfigMap..."

--- a/test/e2e/scripts/LOCAL-DEPLOY.md
+++ b/test/e2e/scripts/LOCAL-DEPLOY.md
@@ -1,6 +1,6 @@
 # MaaS Local Deployment Guide
 
-One-click local deployment of the full MaaS + BBR platform on Kind (macOS + Linux/WSL2).
+One-click local deployment of the full MaaS + IPP platform on Kind (macOS + Linux/WSL2).
 
 ## Quick Start
 
@@ -9,7 +9,7 @@ One-click local deployment of the full MaaS + BBR platform on Kind (macOS + Linu
 ./test/e2e/scripts/local-deploy.sh
 
 # Rebuild a single component after code changes (~30 seconds)
-./test/e2e/scripts/local-deploy.sh --rebuild bbr
+./test/e2e/scripts/local-deploy.sh --rebuild ipp
 ./test/e2e/scripts/local-deploy.sh --rebuild maas-api
 ./test/e2e/scripts/local-deploy.sh --rebuild maas-controller
 ./test/e2e/scripts/local-deploy.sh --rebuild all
@@ -39,11 +39,11 @@ One-click local deployment of the full MaaS + BBR platform on Kind (macOS + Linu
 
 No other repos need to be cloned. The script auto-clones what it needs.
 
-> **How BBR works**: The BBR (payload-processing) **deployment manifests** (Deployment, Service,
+> **How IPP works**: The IPP (payload-processing) **deployment manifests** (Deployment, Service,
 > EnvoyFilter) live inside this repo at `deployment/base/payload-processing/`. This is the same
-> as OpenShift — the MaaS kustomize overlay includes BBR. The image tag and upstream source commit
+> as OpenShift — the MaaS kustomize overlay includes IPP. The image tag and upstream source commit
 > are pinned in `deployment/overlays/odh/params.env` (`payload-processing-image`); override locally
-> with `BBR_IMAGE` or `PAYLOAD_PROCESSING_COMMIT`. On Apple Silicon, the pre-built quay.io image is
+> with `IPP_IMAGE` or `PAYLOAD_PROCESSING_COMMIT`. On Apple Silicon, the pre-built quay.io image is
 > x86-only, so the script **auto-clones** `ai-gateway-payload-processing` to
 > `../ai-gateway-payload-processing`, checks out the pinned commit, and builds an arm64 image locally.
 > On x86, the pre-built image is used directly.
@@ -57,7 +57,7 @@ Kind cluster (maas-local)
 +-- istio-system (3 pods)
 |   +-- istiod                          # Istio control plane
 |   +-- maas-default-gateway-istio      # Gateway (MetalLB assigns LB IP)
-|   +-- payload-processing              # BBR ext-proc (body-based routing)
+|   +-- payload-processing              # IPP ext-proc (body-based routing)
 |
 +-- kuadrant-system (6 pods)
 |   +-- kuadrant-operator               # Manages auth/rate-limit policies
@@ -106,7 +106,7 @@ Kind cluster (maas-local)
 | Authorino CA trust | service-ca bundle in system trust store | Init container injects CA into SSL_CERT_FILE |
 | PostgreSQL | registry.redhat.io/rhel9/postgresql-16 | postgres:16-alpine |
 | LoadBalancer | Cloud provider / OpenShift router | MetalLB |
-| BBR EnvoyFilter | INSERT_AFTER openshift-ingress.kuadrant-... | INSERT_AFTER istio-system.kuadrant-... |
+| IPP EnvoyFilter | INSERT_AFTER openshift-ingress.kuadrant-... | INSERT_AFTER istio-system.kuadrant-... |
 | External model TLS | Real provider certs (trusted) | Let's Encrypt via sslip.io (trusted) |
 
 ## Request Flow
@@ -125,7 +125,7 @@ Gateway (port 80)                                    # identical to OpenShift
   |     +-- API key? -> Authorino -> maas-api:8443   # identical to OpenShift
   |     +-- K8s token? -> Authorino -> TokenReview   # identical to OpenShift
   |
-  +-- BBR ext-proc (payload-processing)              # identical to OpenShift
+  +-- IPP ext-proc (payload-processing)              # identical to OpenShift
   |     |
   |     +-- Extract model name from request body
   |     +-- Resolve ExternalModel -> set X-Gateway-Model-Name header
@@ -219,7 +219,7 @@ kubectl logs -n maas-system deployment/maas-controller -f
 # Authorino (auth decisions)
 kubectl logs -n kuadrant-system deployment/authorino -f
 
-# BBR (payload processing)
+# IPP (payload processing)
 kubectl logs -n istio-system deployment/payload-processing -f
 
 # Gateway proxy (Envoy access logs)
@@ -297,11 +297,11 @@ After the initial deploy, use `--rebuild` to quickly test code changes without
 redeploying the full infrastructure:
 
 ```bash
-# Example: you changed BBR plugin code
+# Example: you changed IPP plugin code
 cd ../ai-gateway-payload-processing
 # ... edit code ...
 cd ../models-as-a-service
-./test/e2e/scripts/local-deploy.sh --rebuild bbr    # ~30 seconds
+./test/e2e/scripts/local-deploy.sh --rebuild ipp    # ~30 seconds
 
 # Example: you changed maas-api handler
 # ... edit maas-api code ...
@@ -337,7 +337,7 @@ deployment. The cluster, Istio, Kuadrant, and all CRDs stay untouched.
 | MaaS (api + controller) | ~60m | ~640Mi |
 | PostgreSQL | ~100m | ~512Mi |
 | KServe (3 pods) | ~100m | ~384Mi |
-| BBR (payload-processing) | ~100m | ~128Mi |
+| IPP (payload-processing) | ~100m | ~128Mi |
 | llm-d simulator | ~100m | ~256Mi |
 | **Total** | **~1.5 CPU** | **~4Gi** |
 

--- a/test/e2e/scripts/local-demo.sh
+++ b/test/e2e/scripts/local-demo.sh
@@ -45,7 +45,7 @@ API_KEY=$(kubectl exec -n maas-system deployment/maas-api -- curl -sk \
 
 echo -e "${BOLD}${CYAN}1. What's running${NC}"
 echo ""
-echo -e "  30 pods, 8 namespaces — full MaaS + BBR + Kuadrant + KServe stack"
+echo -e "  30 pods, 8 namespaces — full MaaS + IPP + Kuadrant + KServe stack"
 echo ""
 
 for ns in istio-system kuadrant-system maas-system kserve; do
@@ -87,7 +87,7 @@ pause
 
 echo -e "${BOLD}${CYAN}3. External model inference (llm-katan on AWS, Let's Encrypt TLS)${NC}"
 echo ""
-echo -e "  Request → Gateway → Kuadrant auth → BBR (model resolve + credential inject) → llm-katan"
+echo -e "  Request → Gateway → Kuadrant auth → IPP (model resolve + credential inject) → llm-katan"
 echo ""
 echo -e "  $ curl http://gateway/llm/llm-katan-openai/v1/chat/completions"
 
@@ -130,7 +130,7 @@ echo -e "${BOLD}${CYAN}5. Fast iteration: --rebuild${NC}"
 echo ""
 echo -e "  After a code change in any component:"
 echo ""
-echo -e "  $ ./local-deploy.sh --rebuild bbr             # ~15 seconds"
+echo -e "  $ ./local-deploy.sh --rebuild ipp             # ~15 seconds"
 echo -e "  $ ./local-deploy.sh --rebuild maas-api         # ~15 seconds"
 echo -e "  $ ./local-deploy.sh --rebuild maas-controller  # ~15 seconds"
 echo -e "  $ ./local-deploy.sh --rebuild all              # ~45 seconds"
@@ -146,7 +146,7 @@ echo -e "${BOLD}${CYAN}Summary${NC}"
 echo ""
 echo "  One script deploys the full MaaS platform locally:"
 echo "    - MaaS API + Controller (TLS backend, matching OpenShift)"
-echo "    - BBR (payload-processing, ext-proc body routing)"
+echo "    - IPP (payload-processing, ext-proc body routing)"
 echo "    - Kuadrant (auth + rate limiting)"
 echo "    - KServe (LLMInferenceService for internal models)"
 echo "    - PostgreSQL, Istio, cert-manager, MetalLB"

--- a/test/e2e/scripts/local-deploy.sh
+++ b/test/e2e/scripts/local-deploy.sh
@@ -15,8 +15,8 @@
 #   KUADRANT_VERSION     - Kuadrant Helm chart version (default: 1.3.1)
 #   MAAS_NAMESPACE       - MaaS deployment namespace (default: maas-system)
 #   GATEWAY_NAMESPACE    - Gateway namespace (default: istio-system)
-#   BBR_IMAGE            - Payload-processing image (default: see params.env pin)
-#   PAYLOAD_PROCESSING_COMMIT - Upstream repo commit for local BBR builds (default: BBR_IMAGE tag)
+#   IPP_IMAGE            - Payload-processing image (default: see params.env pin)
+#   PAYLOAD_PROCESSING_COMMIT - Upstream repo commit for local IPP builds (default: IPP_IMAGE tag)
 
 set -euo pipefail
 
@@ -37,16 +37,16 @@ SUBSCRIPTION_NAMESPACE="models-as-a-service"
 MAAS_API_IMAGE="${MAAS_API_IMAGE:-quay.io/opendatahub/maas-api:latest}"
 MAAS_CONTROLLER_IMAGE="${MAAS_CONTROLLER_IMAGE:-quay.io/opendatahub/maas-controller:latest}"
 
-BBR_IMAGE="${BBR_IMAGE:-quay.io/opendatahub/odh-ai-gateway-payload-processing:ed049f48739fc4c52f30080c4337073595fd95b6}"
-PAYLOAD_PROCESSING_COMMIT="${PAYLOAD_PROCESSING_COMMIT:-${BBR_IMAGE##*:}}"
+_default_ipp_image=$(awk -F= '/^payload-processing-image=/ {print $2; exit}' "$PROJECT_ROOT/deployment/overlays/odh/params.env" 2>/dev/null || echo "quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable")
+IPP_IMAGE="${IPP_IMAGE:-$_default_ipp_image}"
+PAYLOAD_PROCESSING_COMMIT="${PAYLOAD_PROCESSING_COMMIT:-${IPP_IMAGE##*:}}"
 
-# Path to BBR repo (for arm64 image builds)
-BBR_REPO="${BBR_REPO:-$(cd "$PROJECT_ROOT/../ai-gateway-payload-processing" 2>/dev/null && pwd || echo "")}"
+# Path to IPP repo (for arm64 image builds)
+IPP_REPO="${IPP_REPO:-$(cd "$PROJECT_ROOT/../ai-gateway-payload-processing" 2>/dev/null && pwd || echo "")}"
 
 # KServe (for LLMInferenceService / internal models)
 KSERVE_VERSION="${KSERVE_VERSION:-v0.15.2}"
 KSERVE_COMMIT="47894470ea49"  # opendatahub fork commit pinned in maas-controller go.mod
-KSERVE_ODH_IMAGE="quay.io/opendatahub/kserve-controller:latest"
 LLMISVC_IMAGE="quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-stable"
 
 ARCH="$(uname -m)"
@@ -78,21 +78,21 @@ ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
 warn() { echo -e "  ${YELLOW}!${NC} $1"; }
 fail() { echo -e "  ${RED}✗${NC} $1" >&2; }
 
-ensure_bbr_repo() {
-  if [[ -z "${BBR_REPO:-}" || ! -d "$BBR_REPO" ]]; then
-    BBR_REPO="$PROJECT_ROOT/../ai-gateway-payload-processing"
+ensure_ipp_repo() {
+  if [[ -z "${IPP_REPO:-}" || ! -d "$IPP_REPO" ]]; then
+    IPP_REPO="$PROJECT_ROOT/../ai-gateway-payload-processing"
   fi
-  if [[ ! -d "$BBR_REPO/.git" ]]; then
+  if [[ ! -d "$IPP_REPO/.git" ]]; then
     echo "  Cloning ai-gateway-payload-processing..."
-    gh repo clone opendatahub-io/ai-gateway-payload-processing "$BBR_REPO"
+    gh repo clone opendatahub-io/ai-gateway-payload-processing "$IPP_REPO"
   fi
   local current
-  current="$(git -C "$BBR_REPO" rev-parse HEAD 2>/dev/null || echo "")"
+  current="$(git -C "$IPP_REPO" rev-parse HEAD 2>/dev/null || echo "")"
   if [[ "$current" != "$PAYLOAD_PROCESSING_COMMIT" ]]; then
     echo "  Checking out payload-processing commit ${PAYLOAD_PROCESSING_COMMIT:0:12}..."
-    git -C "$BBR_REPO" fetch origin "$PAYLOAD_PROCESSING_COMMIT" --depth 1 2>/dev/null \
-      || git -C "$BBR_REPO" fetch origin
-    git -C "$BBR_REPO" checkout "$PAYLOAD_PROCESSING_COMMIT"
+    git -C "$IPP_REPO" fetch origin "$PAYLOAD_PROCESSING_COMMIT" --depth 1 2>/dev/null \
+      || git -C "$IPP_REPO" fetch origin
+    git -C "$IPP_REPO" checkout "$PAYLOAD_PROCESSING_COMMIT"
   fi
 }
 
@@ -109,7 +109,7 @@ while [[ $# -gt 0 ]]; do
       ACTION="rebuild"
       REBUILD_COMPONENT="${2:-}"
       if [[ -z "$REBUILD_COMPONENT" ]] || [[ "$REBUILD_COMPONENT" == --* ]]; then
-        echo "Usage: $0 --rebuild <bbr|maas-api|maas-controller>"
+        echo "Usage: $0 --rebuild <ipp|maas-api|maas-controller>"
         exit 1
       fi
       shift
@@ -124,7 +124,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --status                Show component status"
       echo "  --validate              Run inference tests to verify the deployment works"
       echo "  --rebuild <component>   Rebuild and redeploy a component after code changes"
-      echo "                          Components: bbr, maas-api, maas-controller, all"
+      echo "                          Components: ipp, maas-api, maas-controller, all"
       echo "  --help                  Show this help message"
       echo ""
       echo "Environment variables:"
@@ -208,7 +208,7 @@ if [[ "$ACTION" == "validate" ]]; then
   _check "All pods running" '[[ $(kubectl get pods -A --no-headers | grep -v Running | grep -v Completed | wc -l) -eq 0 ]]'
   _check "maas-api ready" 'kubectl get deployment maas-api -n $MAAS_NAMESPACE -o jsonpath="{.status.readyReplicas}" | grep -q 1'
   _check "maas-controller ready" 'kubectl get deployment maas-controller -n $MAAS_NAMESPACE -o jsonpath="{.status.readyReplicas}" | grep -q 1'
-  _check "payload-processing (BBR) ready" 'kubectl get deployment payload-processing -n $GATEWAY_NAMESPACE -o jsonpath="{.status.readyReplicas}" | grep -q 1'
+  _check "payload-processing (IPP) ready" 'kubectl get deployment payload-processing -n $GATEWAY_NAMESPACE -o jsonpath="{.status.readyReplicas}" | grep -q 1'
   _check "Authorino ready" 'kubectl get deployment authorino -n kuadrant-system -o jsonpath="{.status.readyReplicas}" | grep -q 1'
   _check "Gateway programmed" 'kubectl get gateway maas-default-gateway -n $GATEWAY_NAMESPACE -o jsonpath="{.status.conditions[?(@.type==\"Programmed\")].status}" | grep -q True'
 
@@ -322,18 +322,18 @@ if [[ "$ACTION" == "rebuild" ]]; then
   fi
   kubectl config use-context "kind-${KIND_CLUSTER_NAME}" &>/dev/null
 
-  ensure_bbr_repo
+  ensure_ipp_repo
 
   case "$REBUILD_COMPONENT" in
-    bbr|payload-processing)
-      echo -e "${BOLD}Rebuilding BBR (payload-processing)${NC}"
-      (cd "$BBR_REPO" && \
+    ipp|payload-processing)
+      echo -e "${BOLD}Rebuilding IPP (payload-processing)${NC}"
+      (cd "$IPP_REPO" && \
         docker buildx build --platform "$DOCKER_PLATFORM" --load \
-          -t "$BBR_IMAGE" . 2>&1 | tail -3)
-      kind load docker-image "$BBR_IMAGE" --name "$KIND_CLUSTER_NAME"
+          -t "$IPP_IMAGE" . 2>&1 | tail -3)
+      kind load docker-image "$IPP_IMAGE" --name "$KIND_CLUSTER_NAME"
       kubectl rollout restart deployment/payload-processing -n "$GATEWAY_NAMESPACE"
       kubectl rollout status deployment/payload-processing -n "$GATEWAY_NAMESPACE" --timeout=60s
-      ok "BBR rebuilt and redeployed"
+      ok "IPP rebuilt and redeployed"
       ;;
     maas-api|api)
       echo -e "${BOLD}Rebuilding maas-api${NC}"
@@ -372,11 +372,11 @@ if [[ "$ACTION" == "rebuild" ]]; then
           -t "$MAAS_CONTROLLER_IMAGE" . 2>&1 | tail -3)
       kind load docker-image "$MAAS_CONTROLLER_IMAGE" --name "$KIND_CLUSTER_NAME"
 
-      echo "  Building BBR..."
-      (cd "$BBR_REPO" && \
+      echo "  Building IPP..."
+      (cd "$IPP_REPO" && \
         docker buildx build --platform "$DOCKER_PLATFORM" --load \
-          -t "$BBR_IMAGE" . 2>&1 | tail -3)
-      kind load docker-image "$BBR_IMAGE" --name "$KIND_CLUSTER_NAME"
+          -t "$IPP_IMAGE" . 2>&1 | tail -3)
+      kind load docker-image "$IPP_IMAGE" --name "$KIND_CLUSTER_NAME"
 
       kubectl rollout restart deployment/maas-api -n "$MAAS_NAMESPACE"
       kubectl rollout restart deployment/maas-controller -n "$MAAS_NAMESPACE"
@@ -388,7 +388,7 @@ if [[ "$ACTION" == "rebuild" ]]; then
       ;;
     *)
       fail "Unknown component: $REBUILD_COMPONENT"
-      echo "  Valid components: bbr, maas-api, maas-controller, all"
+      echo "  Valid components: ipp, maas-api, maas-controller, all"
       exit 1
       ;;
   esac
@@ -1075,13 +1075,13 @@ if [[ "$ARCH" == "arm64" ]]; then
         -t "$MAAS_CONTROLLER_IMAGE" . 2>&1 | tail -3)
     kind load docker-image "$MAAS_CONTROLLER_IMAGE" --name "$KIND_CLUSTER_NAME"
 
-    ensure_bbr_repo
+    ensure_ipp_repo
 
-    echo "  Building payload-processing (BBR)..."
-    (cd "$BBR_REPO" && \
+    echo "  Building payload-processing (IPP)..."
+    (cd "$IPP_REPO" && \
       docker buildx build --platform "$DOCKER_PLATFORM" --load \
-        -t "$BBR_IMAGE" . 2>&1 | tail -3)
-    kind load docker-image "$BBR_IMAGE" --name "$KIND_CLUSTER_NAME"
+        -t "$IPP_IMAGE" . 2>&1 | tail -3)
+    kind load docker-image "$IPP_IMAGE" --name "$KIND_CLUSTER_NAME"
 
     ok "arm64 images built and loaded into Kind"
   else
@@ -1104,7 +1104,7 @@ ln -s "$PROJECT_ROOT/deployment" "$TEMP_DIR/deployment"
 cat > "$TEMP_DIR/params.env" <<EOF
 maas-api-image=${MAAS_API_IMAGE}
 maas-controller-image=${MAAS_CONTROLLER_IMAGE}
-payload-processing-image=${BBR_IMAGE}
+payload-processing-image=${IPP_IMAGE}
 maas-api-key-cleanup-image=docker.io/curlimages/curl:latest
 EOF
 
@@ -1194,7 +1194,7 @@ for _i in $(seq 1 36); do
   sleep 5
 done
 if kubectl get deployment payload-processing -n "$GATEWAY_NAMESPACE" &>/dev/null; then
-  # Disable sidecar injection on payload-processing (BBR uses self-signed TLS for ext-proc).
+  # Disable sidecar injection on payload-processing (IPP uses self-signed TLS for ext-proc).
   kubectl patch deployment payload-processing -n "$GATEWAY_NAMESPACE" --type=merge \
     -p='{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}' 2>/dev/null || true
   kubectl rollout status deployment/payload-processing -n "$GATEWAY_NAMESPACE" --timeout=180s 2>/dev/null || \
@@ -1228,7 +1228,7 @@ metadata:
   name: llm-katan-creds
   namespace: ${MODEL_NAMESPACE}
   labels:
-    inference.networking.k8s.io/bbr-managed: "true"
+    inference.llm-d.ai/ipp-managed: "true"
 stringData:
   api-key: "llm-katan-openai-key"
 ---

--- a/test/e2e/scripts/local-test.sh
+++ b/test/e2e/scripts/local-test.sh
@@ -127,7 +127,7 @@ echo ""
 # Default: run MaaS management tests (API keys, models endpoint).
 # Model inference tests (TestAPIKeyModelInference) are excluded because they
 # hit the model URL directly from the Mac host, which isn't routable to the
-# Kind docker network. These tests work when BBR + gateway egress is configured.
+# Kind docker network. These tests work when IPP + gateway egress is configured.
 #
 # To run all tests: ./local-test.sh --run-all
 # To run specific tests: ./local-test.sh -k test_create_api_key
@@ -153,7 +153,7 @@ if [[ "$RUN_ALL" == "false" && ${#PASSTHROUGH_ARGS[@]} -eq 0 ]]; then
   #   TestAPIKeySubscriptionPhases - creates API keys and hits model endpoint
   #   test_models_endpoint.py     - api_key fixture hits model endpoint in setup
   #
-  # These will work once BBR is deployed and gateway egress to llm-katan is configured.
+  # These will work once IPP is deployed and gateway egress to llm-katan is configured.
   PYTEST_ARGS+=(
     -k "not (TestAPIKeyModelInference or TestAPIKeySubscriptionPhases or test_revoke_keys_rejected_at_gateway or test_revoke_then_create_new_key_works)"
     "${E2E_DIR}/tests/test_api_keys.py"


### PR DESCRIPTION
## Summary
Cherry-pick of PR #1040 (fix: update ipp config format and image to match llm-d framework) to the rhoai-3.5-ea.2 release branch.

JIRA: https://redhat.atlassian.net/browse/RHOAIENG-68937

## Description
- Cherry-picks the squash-merged commit 3d9f8d6d from downstream main
- Updates payload-processing (IPP) deployment manifests from CLI flags (--streaming/--plugin) to --config-file approach
- Switches payload-processing image from pinned SHA to odh-stable tag
- Renames BBR references to IPP across codebase (EnvoyFilter names, env vars, scripts, docs, tests)
- Updates ipp-managed label to match llm-d convention

## How it was tested
- Clean cherry-pick with no conflicts
- Original PR was validated with kustomize manifest validation, codegen verification, and group-test CI

## Risk analysis
- **Risk rating**: 4
- **Why**: Same rationale as the original PR — changes the entire plugin loading mechanism for payload-processing pods, touching 21 files across deployment, controller, API, and test code. The E2E smoke path exercises pod readiness but full plugin chain validation depends on model inference which may not run in default CI. Additionally, this is a cherry-pick to a release branch, increasing deployment risk.

Made with [Cursor](https://cursor.com)