### PR TITLE
fix: disable stage-2 ext_proc on maas-api routes (cherry-pick #1096)

### DIFF
--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -80,6 +80,9 @@ spec:
             envoy.filters.http.ext_proc.ipp-pre:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
               disabled: true
+            envoy.filters.http.ext_proc.ipp:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
     # Disable ext_proc on non-inference routes (maas-api /maas-api/*).
     - applyTo: HTTP_ROUTE
       match:
@@ -93,5 +96,8 @@ spec:
         value:
           typed_per_filter_config:
             envoy.filters.http.ext_proc.ipp-pre:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+            envoy.filters.http.ext_proc.ipp:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
               disabled: true


### PR DESCRIPTION
## Summary

Cherry-pick of upstream PR opendatahub-io/models-as-a-service#1096 into `rhoai-3.5-ea.2`.

## Description

Adds `envoy.filters.http.ext_proc.ipp: disabled: true` to the `typed_per_filter_config` of both maas-api routes (`/v1/models` and `/maas-api/*`) in the payload-processing EnvoyFilter. Previously only the stage-1 `ipp-pre` filter was disabled there.

- Without this fix, `GET /v1/models` through the gateway returns a bare HTTP 500 and crashes the payload-processing pod (nil-pointer panic in the IPP framework for bodyless GETs).
- The pod accumulated 5+ restarts in ~45 minutes from probing this endpoint.
- Clients like Claude Code that probe the models endpoint silently degrade (assume wrong context window size).
- Config-only change, scoped to non-inference maas-api routes; inference traffic is unaffected.

## How it was tested

- Verified clean cherry-pick with no conflicts against current `rhoai-3.5-ea.2` tip.
- Original PR was validated on a live cluster:
  - `GET /v1/models` with valid MaaS key → 200 with aggregated model list.
  - `GET /v1/models` without auth → 401 (Kuadrant auth unaffected).
  - Payload-processing pod: no new restarts after fix.
  - `POST /v1/messages` inference traffic unaffected.

## Risk analysis

**Risk rating**: 2

**Why**: Config-only cherry-pick of a change already validated on live clusters and merged to downstream main. The change is additive (disables an additional ext_proc stage on routes that already exempt stage-1) with no code changes. Low blast radius — only affects non-inference maas-api routes.

Made with [Cursor](https://cursor.com)