### PR TITLE
fix: use Istio managed label in payload-processing NetworkPolicy (cherry-pick #1105)

### DIFF
--- a/deployment/base/payload-processing/default/kustomization.yaml
+++ b/deployment/base/payload-processing/default/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../manager
   - ../rbac
+  - ../networking
 
 labels:
   - includeSelectors: true

--- a/deployment/base/payload-processing/networking/kustomization.yaml
+++ b/deployment/base/payload-processing/networking/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - networkpolicy.yaml

--- a/deployment/base/payload-processing/networking/networkpolicy.yaml
+++ b/deployment/base/payload-processing/networking/networkpolicy.yaml
@@ -1,0 +1,75 @@
+# NetworkPolicy for payload-processing pods in the gateway namespace.
+#
+# Required on OCP 4.22+ where openshift-ingress has a default deny-all
+# NetworkPolicy. Without this, payload-processing pods cannot receive
+# ext_proc traffic from the gateway or reach the Kubernetes API server.
+#
+# Security constraints:
+# - podSelector: covers payload-processing and payload-pre-processing pods
+# - ingress: gateway ext_proc traffic (port 9004), monitoring scrape (9005, 9090)
+# - egress: DNS + Kubernetes API server only (this container is a pure
+#   Kubernetes controller with no external HTTP/gRPC calls)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: payload-processing
+  labels:
+    app.opendatahub.io/modelsasservice: "true"
+    app.kubernetes.io/part-of: maas
+    app.kubernetes.io/component: networking
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - payload-processing
+          - payload-pre-processing
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow ext_proc traffic from any Istio-managed gateway pod in the
+    # ingress namespace. Uses the common label applied by the Istio gateway
+    # controller to all provisioned gateway pods, covering both
+    # data-science-gateway and maas-default-gateway.
+    - from:
+        - podSelector:
+            matchLabels:
+              gateway.istio.io/managed: istio.io-gateway-controller
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-ingress
+      ports:
+        - protocol: TCP
+          port: 9004
+    # Allow monitoring scrape from OpenShift monitoring namespaces
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: 9005
+        - protocol: TCP
+          port: 9090
+  egress:
+    # Allow DNS resolution (CoreDNS on OCP uses port 5353)
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Allow Kubernetes API server access (controller-runtime client)
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443


### PR DESCRIPTION
## Summary

Cherry-pick of upstream PR opendatahub-io/models-as-a-service#1105 into `rhoai-3.4` (deployment-only, E2E test excluded).

## Description

The payload-processing pods had no NetworkPolicy on OCP 4.22+ clusters where `openshift-ingress` has a default deny-all policy. This blocked ext_proc gRPC traffic from gateway pods to payload-processing, resulting in gRPC error 14 (UNAVAILABLE) → HTTP 500s and 10s+ timeouts on all inference requests.

**Root cause**: Without a NetworkPolicy granting ingress, the default deny-all in `openshift-ingress` drops every connection from gateway pods to payload-processing on port 9004.

**Fix**:
- Introduces a `NetworkPolicy` for payload-processing pods with:
  - **Ingress**: ext_proc traffic (port 9004) from all Istio-managed gateway pods (`gateway.istio.io/managed: istio.io-gateway-controller`), monitoring scrape (9005, 9090) from OpenShift monitoring namespaces.
  - **Egress**: DNS (53/5353) + Kubernetes API (443/6443) only — payload-processing is a pure ext_proc server using controller-runtime, with no external HTTP/gRPC calls.
- Uses `gateway.istio.io/managed` label (standard Istio) rather than hardcoding a single gateway name, covering `maas-default-gateway` and any future per-tenant gateways.

**What was excluded from this cherry-pick**:
- `test/e2e/tests/test_networkpolicy.py` — depends on `multitenancy_helpers.py` which does not exist in the `rhoai-3.4` branch. The test validates the NetworkPolicy selector and connectivity but cannot run without its dependency module.

**Impact on existing rhoai-3.4 functionality**:
- The `payload-processing` pod in 3.4 only needs Kubernetes API access (configmaps, secrets, ExternalModel CRDs) and DNS — both allowed by the egress rules.
- Ingress from gateway pods on port 9004 is explicitly allowed, so ext_proc traffic continues to flow.
- Existing E2E tests (`test_smoke`, `test_models_endpoint`, `test_subscription`, etc.) are unaffected — they exercise the gateway → payload-processing path which remains permitted.

Fixes https://redhat.atlassian.net/browse/RHOAIENG-71268 and https://redhat.atlassian.net/browse/RHOAIENG-75511

## How it was tested

- Verified clean cherry-pick with no git conflicts against current `rhoai-3.4` tip.
- Confirmed `kustomize build` of the payload-processing default bundle includes the new NetworkPolicy.
- Original PR validated on `dash-e2e-rhoai` cluster: requests went from 10s hang + 500 to 30ms + 200 after applying the fix.
- Reviewed payload-processing RBAC and deployment spec in rhoai-3.4 to confirm egress rules (DNS + k8s API only) are sufficient — pod uses controller-runtime watches only, no outbound HTTP/gRPC.

## Risk analysis

**Risk rating**: 3

**Why**: Introduces a NetworkPolicy that restricts ingress/egress for payload-processing pods. On clusters without OCP 4.22 default deny-all, the policy is additive and harmless. On 4.22+ clusters, it's required for functionality. The Istio managed label is standard and verified on live clusters. Slightly elevated risk because the E2E test validating the policy is not included in this branch, so regressions would only be caught by existing smoke/integration tests exercising the gateway path.

Made with [Cursor](https://cursor.com)