### PR TITLE
fix: cherry-pick Cron Job TLS setup

### DIFF
--- a/deployment/base/maas-api/core/networkpolicy-cleanup.yaml
+++ b/deployment/base/maas-api/core/networkpolicy-cleanup.yaml
@@ -22,10 +22,16 @@ spec:
     ports:
     - protocol: TCP
       port: 8080
-  # Allow DNS resolution
+  # Allow DNS resolution. OVN-Kubernetes evaluates egress rules after DNAT;
+  # OpenShift CoreDNS listens on port 5353 (Service 53 → targetPort 5353),
+  # so both ports must be allowed.
   - to:
     ports:
     - protocol: UDP
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353

--- a/deployment/base/maas-api/overlays/tls/cronjob-cleanup-patch.yaml
+++ b/deployment/base/maas-api/overlays/tls/cronjob-cleanup-patch.yaml
@@ -1,0 +1,17 @@
+# CronJob base uses http://maas-api:8080; TLS overlay exposes HTTPS on 8443 only.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: maas-api-key-cleanup
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cleanup
+            command:
+            - /bin/sh
+            - -c
+            - |
+              curl -sf -k -X POST https://maas-api:8443/internal/v1/api-keys/cleanup

--- a/deployment/base/maas-api/overlays/tls/kustomization.yaml
+++ b/deployment/base/maas-api/overlays/tls/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
 patches:
   - path: deployment-patch.yaml
   - path: service-patch.yaml
+  - path: cronjob-cleanup-patch.yaml
+  - path: networkpolicy-cleanup-patch.yaml
   - target:
       group: gateway.networking.k8s.io
       version: v1

--- a/deployment/base/maas-api/overlays/tls/networkpolicy-cleanup-patch.yaml
+++ b/deployment/base/maas-api/overlays/tls/networkpolicy-cleanup-patch.yaml
@@ -1,0 +1,29 @@
+# Base policy allows TCP 8080; TLS overlay serves HTTPS on 8443 only.
+# Strategic merge replaces the whole egress list, so include DNS egress here too
+# (same as base networkpolicy-cleanup.yaml).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: maas-api-cleanup-restrict
+spec:
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/name: maas-api
+          app.kubernetes.io/part-of: models-as-a-service
+    ports:
+    - protocol: TCP
+      port: 8443
+  # Allow DNS resolution (see base networkpolicy-cleanup.yaml for details).
+  - to:
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --> https://redhat.atlassian.net/browse/RHOAIENG-58184

## Description
<!--- Describe your changes in detail -->
Adding a TLS patch for CronJob and NetworkPolicy to match the correct port of MaaS API. Also allowing another port `5353` for DNS resolution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> <!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. --> Job is completed with the update.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
* Automated API key cleanup now executes on a recurring schedule to maintain system integrity.

* **Infrastructure**
* Enhanced network policies to support expanded DNS resolution endpoints for improved service flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->