### PR TITLE
fix: [rhoai-3.4] add CEL has() guards to telemetry cost_center and organization_id labels

### DIFF
--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -315,10 +315,10 @@ func buildTelemetryLabels(log logr.Logger, config *maasv1alpha1.TenantTelemetryC
 	}
 	labels := map[string]any{
 		"subscription": "auth.identity.selected_subscription",
-		"cost_center":  "auth.identity.subscription_info.costCenter",
+		"cost_center":  `has(auth.identity.subscription_info.costCenter) ? auth.identity.subscription_info.costCenter : ""`,
 	}
 	if captureOrganization {
-		labels["organization_id"] = "auth.identity.subscription_info.organizationId"
+		labels["organization_id"] = `has(auth.identity.subscription_info.organizationId) ? auth.identity.subscription_info.organizationId : ""`
 	}
 	if captureUser {
 		log.Info("WARNING: User identity metrics enabled - ensure GDPR/privacy compliance", "field", "captureUser", "value", true)


### PR DESCRIPTION
## Summary

Cherry-pick of opendatahub-io/models-as-a-service#1276 to `rhoai-3.4` for 3.4.4 release.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-80096

`buildTelemetryLabels` unconditionally includes `cost_center` and conditionally includes `organization_id` in the TelemetryPolicy. When these fields are missing from the subscription response (common case), the wasm-shim crashes with `CelError::Resolve { NoSuchKey("costCenter") }` and drops the entire rate limit descriptor — `authorized_hits` stops incrementing and the MaaS monitoring dashboard shows all zeros.

Adds CEL `has()` guards so missing fields resolve to empty string instead of crashing.

Upstream PRs:
- opendatahub-io/models-as-a-service#1276 (main)
- opendatahub-io/models-as-a-service#1311 (release-3.4)

## Validation

- Verified on RHOAI 3.4.2 cluster: metrics showed up correctly with `has()` guards
- Verified on RHOAI 3.5 cluster: zero CEL errors, TelemetryPolicy Accepted+Enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)