### PR TITLE
chore: sync rhoai-3.5 with opendatahub-io/models-as-a-service stable

### DIFF
--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -14,10 +14,9 @@ spec:
   # any EnvoyFilter patches.
   # See: https://istio.io/latest/docs/reference/config/networking/envoy-filter/#EnvoyFilter
   priority: 10
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: maas-default-gateway
+  workloadSelector:
+    labels:
+      gateway.networking.k8s.io/gateway-name: maas-default-gateway
   configPatches:
     # Stage 1: must run BEFORE the WasmPlugin so auth sees X-Gateway-Model-Name.
     - applyTo: HTTP_FILTER

--- a/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml
+++ b/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml
@@ -37,10 +37,9 @@ metadata:
     app.kubernetes.io/part-of: maas-observability
     app.kubernetes.io/managed-by: maas-controller
 spec:
-  targetRefs:
-  - group: gateway.networking.k8s.io
-    kind: Gateway
-    name: maas-default-gateway
+  workloadSelector:
+    labels:
+      gateway.networking.k8s.io/gateway-name: maas-default-gateway
   configPatches:
 
   # ── Cluster: gRPC endpoint to OTel Collector ──────────────────────────

--- a/docs/content/configuration-and-management/model-setup.md
+++ b/docs/content/configuration-and-management/model-setup.md
@@ -59,6 +59,9 @@ To enable MaaS policies for an LLMInferenceService:
 
 Without the gateway reference, the model uses the standard gateway and MaaS policies do not apply.
 
+!!! tip "Multi-tenant deployments"
+    For models that serve a non-default tenant, set `spec.tenantRef` on the MaaSModelRef to the AITenant name. This tells the controller to resolve the gateway from the named AITenant instead of using namespace-based inference. See [Multi-Tenant Setup — Configure Models](../install/multi-tenant-setup.md#5-configure-models).
+
 ---
 
 ## External Models

--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -221,25 +221,34 @@ See [Tenant RBAC](../configuration-and-management/tenant-rbac.md) for examples w
 
 ## 5. Configure Models
 
-Create MaaS resources in the tenant namespace to expose models:
+Create the MaaSModelRef in the **model namespace** (co-located with the backend resource) and use `tenantRef` to associate it with the tenant's gateway. MaaSAuthPolicy and MaaSSubscription must be created in the **tenant namespace** (where the MaasTenantConfig CR lives).
 
 ```bash
 TENANT_NS="ai-tenant-${TENANT_NAME}"
+MODEL_NS="llm"   # namespace where the LLMInferenceService runs
 
-# Create a MaaSModelRef
+# The model namespace must carry the tenant Gateway's access label
+# so the controller-generated HTTPRoute can attach.
+oc label namespace "${MODEL_NS}" "maas.opendatahub.io/gateway-access-${TENANT_NAME}=true" --overwrite
+
+# Create a MaaSModelRef in the model namespace.
+# tenantRef tells the controller to resolve the gateway from this AITenant
+# instead of using namespace-based inference (which defaults to the default tenant).
 cat <<EOF | oc apply -f -
 apiVersion: maas.opendatahub.io/v1alpha1
 kind: MaaSModelRef
 metadata:
   name: my-model
-  namespace: ${TENANT_NS}
+  namespace: ${MODEL_NS}
 spec:
   modelRef:
+    kind: LLMInferenceService
     name: my-llm-inference-service
-    namespace: llm
+  tenantRef: ${TENANT_NAME}
 EOF
 
-# Create a MaaSAuthPolicy
+# Create a MaaSAuthPolicy in the tenant namespace.
+# modelRefs point to the MaaSModelRef by name and namespace.
 cat <<EOF | oc apply -f -
 apiVersion: maas.opendatahub.io/v1alpha1
 kind: MaaSAuthPolicy
@@ -249,14 +258,14 @@ metadata:
 spec:
   modelRefs:
     - name: my-model
-      namespace: ${TENANT_NS}
+      namespace: ${MODEL_NS}
   subjects:
     groups:
       - name: system:authenticated
     users: []
 EOF
 
-# Create a MaaSSubscription
+# Create a MaaSSubscription in the tenant namespace.
 cat <<EOF | oc apply -f -
 apiVersion: maas.opendatahub.io/v1alpha1
 kind: MaaSSubscription
@@ -270,7 +279,7 @@ spec:
     users: []
   modelRefs:
     - name: my-model
-      namespace: ${TENANT_NS}
+      namespace: ${MODEL_NS}
       tokenRateLimits:
         - limit: 1000
           window: 1m
@@ -279,6 +288,9 @@ EOF
 
 !!! note
     MaaSAuthPolicy and MaaSSubscription must be created in a namespace that contains a `MaasTenantConfig` CR. The admission webhook rejects them otherwise.
+
+!!! tip "MaaSModelRef for the default tenant"
+    For models that belong to the default tenant, `tenantRef` can be omitted. The controller falls back to namespace-based gateway resolution. See [MaaSModelRef CRD Reference](../reference/crds/maas-model-ref.md#multi-tenant-models) for details.
 
 ## Webhook Validation
 
@@ -292,7 +304,7 @@ The AITenant admission webhook enforces two rules:
 
 ### Self-Bootstrap
 
-On startup, the controller automatically creates `AITenant/models-as-a-service` in the infrastructure namespace for the default tenant. This AITenant bootstraps the default tenant namespace and Tenant CR.
+On startup, the controller automatically creates `AITenant/models-as-a-service` in the infrastructure namespace for the default tenant. This AITenant bootstraps the default tenant namespace and `MaasTenantConfig` CR.
 
 ### Namespace Discovery
 

--- a/docs/content/reference/crds/maas-model-ref.md
+++ b/docs/content/reference/crds/maas-model-ref.md
@@ -12,6 +12,7 @@ Identifies an AI/ML model for the MaaS platform. The backend may be on-cluster (
 |-------|------|----------|-------------|
 | modelRef | ModelReference | Yes | Reference to the model backend (kind and name) |
 | endpointOverride | string | No | Optional override for the endpoint URL. See [Endpoint Override](#endpoint-override) below. |
+| tenantRef | string | No | Name of the AITenant this model belongs to. When omitted, the model is assigned to the default tenant. See [Multi-Tenant Models](#multi-tenant-models) below. |
 
 ### ModelReference
 
@@ -102,6 +103,34 @@ The override does not bypass backend validation. The controller still checks tha
 
 ---
 
+## Multi-Tenant Models
+
+By default, the controller resolves the gateway for a MaaSModelRef using namespace-based inference — it looks for a MaasTenantConfig in the model's namespace and uses the associated default-tenant gateway.
+
+In multi-tenant deployments, models often live in a shared namespace (e.g. `llm`) but need to route through a specific tenant's gateway. Set `spec.tenantRef` to the name of the AITenant. The controller looks up the AITenant in the AITenant namespace and uses its gateway directly.
+
+A validating webhook rejects `tenantRef` values that do not match an existing AITenant. The value must use lowercase alphanumeric characters and hyphens (matching the CRD pattern `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`) and be no longer than 253 characters.
+
+**Example:**
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: granite-7b
+  namespace: llm
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: granite-7b-instruct
+  tenantRef: red-team
+```
+
+The resolved tenant appears in `status.resolvedTenantRef`. When `tenantRef` is removed or left empty, the field is cleared and the controller reverts to namespace-based resolution.
+
+For step-by-step instructions, see [Multi-Tenant Setup — Configure Models](../../install/multi-tenant-setup.md#5-configure-models).
+
+---
+
 ## Status
 
 ### MaaSModelRefStatus
@@ -115,6 +144,7 @@ The override does not bypass backend validation. The controller still checks tha
 | httpRouteGatewayName | string | Name of the Gateway that the HTTPRoute references |
 | httpRouteGatewayNamespace | string | Namespace of the Gateway that the HTTPRoute references |
 | httpRouteHostnames | []string | Hostnames configured on the HTTPRoute |
+| resolvedTenantRef | string | The explicitly selected AITenant from `spec.tenantRef`; empty when `tenantRef` is omitted and namespace-based resolution is used. |
 | conditions | []Condition | Latest observations of the model's state |
 
 ---

--- a/maas-api/deploy/overlays/xks/kustomization.yaml
+++ b/maas-api/deploy/overlays/xks/kustomization.yaml
@@ -47,3 +47,26 @@ patches:
     patch: |
       - op: remove
         path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+
+  # Exclude monitoring resources on xKS (PodMonitor CRD requires Prometheus Operator,
+  # NetworkPolicy references OCP-specific redhat-ods-monitoring namespace)
+  - target:
+      group: monitoring.coreos.com
+      version: v1
+      kind: PodMonitor
+      name: maas-api-metrics
+    patch: |
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1
+      kind: PodMonitor
+      metadata:
+        name: maas-api-metrics
+  - target:
+      kind: NetworkPolicy
+      name: maas-api-allow-monitoring
+    patch: |
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: maas-api-allow-monitoring

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -654,22 +654,15 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 		return fmt.Errorf("write EnvoyFilter priority: %w", err)
 	}
 
-	targetRefs, found, err := unstructured.NestedSlice(r.Object, "spec", "targetRefs")
-	if err != nil {
-		return fmt.Errorf("read EnvoyFilter targetRefs: %w", err)
+	if err := unstructured.SetNestedStringMap(r.Object,
+		map[string]string{"gateway.networking.k8s.io/gateway-name": params.GatewayName},
+		"spec", "workloadSelector", "labels"); err != nil {
+		return fmt.Errorf("write EnvoyFilter workloadSelector: %w", err)
 	}
-	if !found || len(targetRefs) == 0 {
-		return errors.New("EnvoyFilter targetRefs not found")
-	}
-	ref, ok := targetRefs[0].(map[string]any)
-	if !ok {
-		return errors.New("EnvoyFilter targetRefs[0] is not an object")
-	}
-	ref["name"] = params.GatewayName
-	targetRefs[0] = ref
-	if err := unstructured.SetNestedSlice(r.Object, targetRefs, "spec", "targetRefs"); err != nil {
-		return fmt.Errorf("write EnvoyFilter targetRefs: %w", err)
-	}
+	// targetRefs and workloadSelector are mutually exclusive (Istio 1.26+). Drop any
+	// leftover targetRefs from older manifests so SSA/admission never sees both.
+	unstructured.RemoveNestedField(r.Object, "spec", "targetRefs")
+	unstructured.RemoveNestedField(r.Object, "spec", "targetRef")
 
 	anchorName := wasmpluginAnchorName(params.GatewayNamespace, params.GatewayName)
 	beforeCluster := grpcClusterName(PayloadPreProcessingDeploymentName(params.TenantIdentifier), params.GatewayNamespace, 9004)

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -317,13 +317,13 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found, "EnvoyFilter spec.priority must be set so RHCL wasm anchors apply after Kuadrant")
 	assert.Equal(t, PayloadProcessingEnvoyFilterPriority, priority)
-	targetRefs, found, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "targetRefs")
+	wsLabels, found, err := unstructured.NestedStringMap(payloadEnvoyFilter.Object, "spec", "workloadSelector", "labels")
 	require.NoError(t, err)
 	require.True(t, found)
-	require.NotEmpty(t, targetRefs)
-	firstTargetRef, ok := targetRefs[0].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, params.GatewayName, firstTargetRef["name"])
+	assert.Equal(t, params.GatewayName, wsLabels["gateway.networking.k8s.io/gateway-name"])
+	_, targetRefsFound, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "targetRefs")
+	require.NoError(t, err)
+	assert.False(t, targetRefsFound, "targetRefs must be cleared; mutually exclusive with workloadSelector")
 
 	// Verify dual-stage filter chain with dual anchors:
 	//   [0..1] WasmPlugin (ODH/community Kuadrant), [2..3] wasm filter (RHCL 1.4),

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -257,21 +257,22 @@ func PayloadProcessingEnvoyFilterReady(ctx context.Context, c client.Client, gat
 			gatewayNamespace, efName, shown, PayloadProcessingEnvoyFilterPriority), nil
 	}
 
-	targetRefs, found, err := unstructured.NestedSlice(ef.Object, "spec", "targetRefs")
+	// Istio 1.26+: targetRefs and workloadSelector are mutually exclusive. MaaS
+	// EnvoyFilters use workloadSelector keyed by gateway-name (see params patch).
+	wsLabels, found, err := unstructured.NestedStringMap(ef.Object, "spec", "workloadSelector", "labels")
 	if err != nil {
-		return false, "", fmt.Errorf("read EnvoyFilter targetRefs: %w", err)
+		return false, "", fmt.Errorf("read EnvoyFilter workloadSelector: %w", err)
 	}
-	if !found || len(targetRefs) == 0 {
-		return false, fmt.Sprintf("EnvoyFilter %s/%s has no targetRefs", gatewayNamespace, efName), nil
-	}
-	ref, ok := targetRefs[0].(map[string]any)
-	if !ok {
-		return false, fmt.Sprintf("EnvoyFilter %s/%s targetRefs[0] is not an object", gatewayNamespace, efName), nil
-	}
-	if name, _ := ref["name"].(string); name != gatewayName {
+	const gatewayNameLabel = "gateway.networking.k8s.io/gateway-name"
+	if !found || wsLabels[gatewayNameLabel] == "" {
 		return false, fmt.Sprintf(
-			"EnvoyFilter %s/%s targetRefs[0].name=%q; expected gateway %q",
-			gatewayNamespace, efName, name, gatewayName), nil
+			"EnvoyFilter %s/%s has no workloadSelector.labels[%q]",
+			gatewayNamespace, efName, gatewayNameLabel), nil
+	}
+	if got := wsLabels[gatewayNameLabel]; got != gatewayName {
+		return false, fmt.Sprintf(
+			"EnvoyFilter %s/%s workloadSelector.labels[%q]=%q; expected gateway %q",
+			gatewayNamespace, efName, gatewayNameLabel, got, gatewayName), nil
 	}
 	return true, "", nil
 }

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline_test.go
@@ -73,11 +73,9 @@ func payloadProcessingEnvoyFilter(ns, efName, gatewayName string, priority *int6
 	ef.SetNamespace(ns)
 	ef.SetName(efName)
 	spec := map[string]any{
-		"targetRefs": []any{
-			map[string]any{
-				"group": "gateway.networking.k8s.io",
-				"kind":  "Gateway",
-				"name":  gatewayName,
+		"workloadSelector": map[string]any{
+			"labels": map[string]any{
+				"gateway.networking.k8s.io/gateway-name": gatewayName,
 			},
 		},
 	}
@@ -125,12 +123,26 @@ func TestPayloadProcessingEnvoyFilterReady(t *testing.T) {
 		assert.Contains(t, detail, "priority=0")
 	})
 
-	t.Run("wrong gateway targetRef", func(t *testing.T) {
+	t.Run("wrong gateway workloadSelector", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithObjects(payloadProcessingEnvoyFilter(gwNS, efName, "other-gw", &prioOK)).Build()
 		ready, detail, err := PayloadProcessingEnvoyFilterReady(context.Background(), c, gwNS, gwName, tenantID)
 		require.NoError(t, err)
 		assert.False(t, ready)
-		assert.Contains(t, detail, "targetRefs[0].name")
+		assert.Contains(t, detail, "workloadSelector.labels")
+		assert.Contains(t, detail, "other-gw")
+	})
+
+	t.Run("missing workloadSelector", func(t *testing.T) {
+		ef := &unstructured.Unstructured{}
+		ef.SetGroupVersionKind(GVKEnvoyFilter)
+		ef.SetNamespace(gwNS)
+		ef.SetName(efName)
+		ef.Object["spec"] = map[string]any{"priority": prioOK}
+		c := fake.NewClientBuilder().WithObjects(ef).Build()
+		ready, detail, err := PayloadProcessingEnvoyFilterReady(context.Background(), c, gwNS, gwName, tenantID)
+		require.NoError(t, err)
+		assert.False(t, ready)
+		assert.Contains(t, detail, "has no workloadSelector")
 	})
 
 	t.Run("ignores default-tenant EnvoyFilter name for secondary tenants", func(t *testing.T) {

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -1074,14 +1074,12 @@ def get_ipp_deployment_env(deployment_name: str, namespace: str = GATEWAY_NAMESP
 
 
 def envoyfilter_target_gateway(name: str, namespace: str = GATEWAY_NAMESPACE) -> str:
+    """Return the gateway this IPP EnvoyFilter selects via workloadSelector."""
     envoyfilter = get_json_or_none("envoyfilter", name, namespace)
     if not envoyfilter:
         return ""
-    spec = envoyfilter.get("spec") or {}
-    target_refs = spec.get("targetRefs") or []
-    if target_refs:
-        return target_refs[0].get("name") or ""
-    return (spec.get("targetRef") or {}).get("name") or ""
+    ws_labels = ((envoyfilter.get("spec") or {}).get("workloadSelector") or {}).get("labels") or {}
+    return ws_labels.get("gateway.networking.k8s.io/gateway-name") or ""
 
 
 def envoyfilter_grpc_cluster_names(envoyfilter: dict) -> list[str]:

--- a/test/e2e/tests/test_per_tenant_ipp_isolation.py
+++ b/test/e2e/tests/test_per_tenant_ipp_isolation.py
@@ -223,18 +223,19 @@ class TestPerTenantIPPInfrastructure:
                 f"{names['processing_deployment']} TENANT_NAMESPACE mismatch: {env!r}"
             )
 
-    def test_per_tenant_envoyfilter_target_ref_isolated(self, ipp_tenant_cases):
+    def test_per_tenant_envoyfilter_workload_selector_isolated(self, ipp_tenant_cases):
         for case in ipp_tenant_cases:
             names = per_tenant_ipp_names(case["tenant_label_name"])
             target = envoyfilter_target_gateway(names["envoyfilter"], GATEWAY_NAMESPACE)
             assert target == case["gateway_name"], (
-                f"{names['envoyfilter']} must target gateway {case['gateway_name']}, got {target!r}"
+                f"{names['envoyfilter']} workloadSelector must select gateway "
+                f"{case['gateway_name']}, got {target!r}"
             )
 
         default_target = envoyfilter_target_gateway("payload-processing", GATEWAY_NAMESPACE)
         assert default_target == DEFAULT_GATEWAY_NAME, (
-            f"default payload-processing EnvoyFilter must target {DEFAULT_GATEWAY_NAME}, "
-            f"got {default_target!r}"
+            f"default payload-processing EnvoyFilter workloadSelector must select "
+            f"{DEFAULT_GATEWAY_NAME}, got {default_target!r}"
         )
 
     def test_per_tenant_envoyfilter_grpc_clusters(self, ipp_tenant_cases):


### PR DESCRIPTION
## Summary

Syncs `rhoai-3.5` with the latest changes from [opendatahub-io/models-as-a-service `stable`](https://github.com/opendatahub-io/models-as-a-service/tree/stable).

This merge brings in 4 commits from upstream stable:

- `e39c1d50` chore: promote main to stable (#1307)
- `928cf698` fix: add workloadSelector to MaaS EnvoyFilters for Istio 1.26 compatibility (#1313)
- `bd42904a` fix(xKS): exclude PodMonitor and monitoring NetworkPolicy from xKS overlay (#1306)
- `68b9593b` docs: document MaaSModelRef tenantRef field from PR #1250 (#1303)

### Changed files (12)

- EnvoyFilters: add `workloadSelector` for Istio 1.26 compatibility
- xKS overlay: exclude PodMonitor and monitoring NetworkPolicy
- Docs: MaaSModelRef `tenantRef` field, model-setup and multi-tenant-setup updates
- Tenant reconcile pipeline/params refactor from upstream
- E2E test updates for per-tenant IPP isolation


Fixes https://redhat.atlassian.net/browse/RHOAIENG-80043

## Test plan

- [ ] Verify merge is clean (no conflicts)
- [ ] `kustomize build` for affected overlays succeeds
- [ ] CI passes on downstream repo
- [ ] Smoke/e2e tests pass after merge


Made with [Cursor](https://cursor.com)