### PR TITLE
fix(RHOAIENG-81214): [rhoai-3.5] remove gateway-default-auth lifecycle, keep maas-gateway-auth on last CR deletion

### DIFF
--- a/deployment/base/maas-controller/default/kustomization.yaml
+++ b/deployment/base/maas-controller/default/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - ../manager
   - ../monitoring
   - ../webhook
-  # Gateway policies (gateway-default-auth, gateway-default-deny) are applied
+  # Gateway policies (gateway-default-deny) are applied
   # separately by deploy.sh so they stay in openshift-ingress; see deploy_via_kustomize.

--- a/deployment/base/maas-controller/policies/gateway-default-deny.yaml
+++ b/deployment/base/maas-controller/policies/gateway-default-deny.yaml
@@ -7,7 +7,7 @@
 # this deny applies to all other paths, including model inference paths
 # (e.g. /llm/..., /production/..., /v1/chat/completions via body-routing).
 #
-# The PRIMARY default deny is gateway-default-auth.yaml (AuthPolicy), which
+# The PRIMARY default deny is maas-gateway-auth (AuthPolicy), which
 # returns 401/403 for unconfigured models. This TRLP is a defense-in-depth layer:
 # if a request somehow passes auth but has no per-route TRLP, it gets 0 tokens -> 429.
 #

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -824,34 +824,26 @@ func (r *AITenantReconciler) deleteTenantGatewayAuthPolicy(ctx context.Context, 
 	}
 
 	authPolicyName := fmt.Sprintf("%s-maas-auth", gatewayRef.Name)
-	authPolicyNames := []string{authPolicyName}
 	if aitenant.Name == tenantreconcile.DefaultAITenantName {
-		authPolicyNames = []string{maasGatewayAuthPolicyName, gatewayDefaultAuthPolicyName}
+		authPolicyName = maasGatewayAuthPolicyName
 	}
 
-	for _, name := range authPolicyNames {
-		authPolicy := &unstructured.Unstructured{}
-		authPolicy.SetGroupVersionKind(tenantreconcile.GVKAuthPolicy)
-		authPolicy.SetName(name)
-		authPolicy.SetNamespace(gatewayRef.Namespace)
+	authPolicy := &unstructured.Unstructured{}
+	authPolicy.SetGroupVersionKind(tenantreconcile.GVKAuthPolicy)
+	authPolicy.SetName(authPolicyName)
+	authPolicy.SetNamespace(gatewayRef.Namespace)
 
-		if err := r.get(ctx, client.ObjectKeyFromObject(authPolicy), authPolicy); err != nil {
-			if isNotFoundError(err) {
-				continue
-			}
-			return fmt.Errorf("get tenant gateway AuthPolicy %s/%s during AITenant deletion: %w", authPolicy.GetNamespace(), authPolicy.GetName(), err)
+	if err := r.get(ctx, client.ObjectKeyFromObject(authPolicy), authPolicy); err != nil {
+		if isNotFoundError(err) {
+			return nil
 		}
-		if !isManaged(authPolicy) {
-			continue
-		}
-		// gateway-default-auth has a generic name, so only delete the instance
-		// that the MaaS controller created. Preserve a same-named user policy.
-		if name == gatewayDefaultAuthPolicyName && authPolicy.GetLabels()["app.kubernetes.io/managed-by"] != "maas-controller" {
-			continue
-		}
-		if err := r.Delete(ctx, authPolicy); client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("delete tenant gateway AuthPolicy %s/%s: %w", authPolicy.GetNamespace(), authPolicy.GetName(), err)
-		}
+		return fmt.Errorf("get tenant gateway AuthPolicy %s/%s during AITenant deletion: %w", authPolicy.GetNamespace(), authPolicy.GetName(), err)
+	}
+	if !isManaged(authPolicy) {
+		return nil
+	}
+	if err := r.Delete(ctx, authPolicy); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("delete tenant gateway AuthPolicy %s/%s: %w", authPolicy.GetNamespace(), authPolicy.GetName(), err)
 	}
 	return nil
 }

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -2677,19 +2677,10 @@ func TestAITenantReconcile_DefaultTenantDeletionCompletesInZeroTenantState(t *te
 	gatewayAuthPolicy.SetLabels(map[string]string{
 		"app.kubernetes.io/managed-by": "maas-controller",
 	})
-	gatewayDefaultAuthPolicy := &unstructured.Unstructured{}
-	gatewayDefaultAuthPolicy.SetGroupVersionKind(tenantreconcile.GVKAuthPolicy)
-	gatewayDefaultAuthPolicy.SetName(gatewayDefaultAuthPolicyName)
-	gatewayDefaultAuthPolicy.SetNamespace(gatewayRef.Namespace)
-	gatewayDefaultAuthPolicy.SetLabels(map[string]string{
-		"app.kubernetes.io/managed-by": "maas-controller",
-		"app.kubernetes.io/part-of":    "maas-controller",
-		"app.kubernetes.io/component":  "default-policy",
-	})
 	cl := fake.NewClientBuilder().
 		WithScheme(s).
 		WithStatusSubresource(&maasv1alpha1.AITenant{}).
-		WithObjects(aitenant, claim, tenantNamespace, userSecret, gatewayAuthPolicy, gatewayDefaultAuthPolicy).
+		WithObjects(aitenant, claim, tenantNamespace, userSecret, gatewayAuthPolicy).
 		Build()
 	r := &AITenantReconciler{
 		Client:           cl,
@@ -2722,67 +2713,12 @@ func TestAITenantReconcile_DefaultTenantDeletionCompletesInZeroTenantState(t *te
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	err = cl.Get(ctx, client.ObjectKeyFromObject(gatewayAuthPolicy), gatewayAuthPolicy)
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	err = cl.Get(ctx, client.ObjectKeyFromObject(gatewayDefaultAuthPolicy), gatewayDefaultAuthPolicy)
-	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
 	var remaining maasv1alpha1.AITenant
 	err = cl.Get(ctx, key, &remaining)
 	if !apierrors.IsNotFound(err) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
-	}
-}
-
-func TestDeleteTenantGatewayAuthPolicy_RecreatedDefaultPolicy(t *testing.T) {
-	s := aitenantTestScheme(t)
-	ctx := context.Background()
-
-	gatewayRef := maasv1alpha1.TenantGatewayRef{Namespace: "openshift-ingress", Name: "maas-default-gateway"}
-	aitenant := &maasv1alpha1.AITenant{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      tenantreconcile.DefaultAITenantName,
-			Namespace: tenantreconcile.DefaultAITenantNamespace,
-		},
-		Status: maasv1alpha1.AITenantStatus{GatewayRef: gatewayRef},
-	}
-
-	for _, tc := range []struct {
-		name         string
-		labels       map[string]string
-		shouldBeKept bool
-	}{
-		{
-			name: "controller-managed policy is deleted when maas-gateway-auth is already gone",
-			labels: map[string]string{
-				"app.kubernetes.io/managed-by": "maas-controller",
-				"app.kubernetes.io/part-of":    "maas-controller",
-				"app.kubernetes.io/component":  "default-policy",
-			},
-		},
-		{
-			name:         "same-named user policy is preserved",
-			shouldBeKept: true,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-			policy := &unstructured.Unstructured{}
-			policy.SetGroupVersionKind(tenantreconcile.GVKAuthPolicy)
-			policy.SetName(gatewayDefaultAuthPolicyName)
-			policy.SetNamespace(gatewayRef.Namespace)
-			policy.SetLabels(tc.labels)
-
-			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(policy).Build()
-			r := &AITenantReconciler{Client: cl, APIReader: cl}
-
-			g.Expect(r.deleteTenantGatewayAuthPolicy(ctx, aitenant)).To(Succeed())
-			err := cl.Get(ctx, client.ObjectKeyFromObject(policy), policy)
-			if tc.shouldBeKept {
-				g.Expect(err).NotTo(HaveOccurred())
-			} else {
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}
-		})
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/conflict_detection_test.go
+++ b/maas-controller/pkg/controller/maas/conflict_detection_test.go
@@ -424,7 +424,7 @@ func TestDetectConflictingAuthPolicies_GatewayTarget(t *testing.T) {
 
 	gatewayAP := &unstructured.Unstructured{}
 	gatewayAP.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	gatewayAP.SetName("gateway-default-auth")
+	gatewayAP.SetName("gateway-scoped-auth")
 	gatewayAP.SetNamespace(namespace)
 	_ = unstructured.SetNestedMap(gatewayAP.Object, map[string]any{
 		"targetRef": map[string]any{

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -438,11 +438,9 @@ const (
 // All MaaSAuthPolicy CRs share this one policy; model identity is resolved dynamically.
 const maasGatewayAuthPolicyName = "maas-gateway-auth"
 
-// gatewayDefaultAuthPolicyName is the static deny-all AuthPolicy deployed by the Tenant
-// reconciler. It must be deleted when maas-gateway-auth is created (two gateway-level
-// AuthPolicies on the same target conflict in Kuadrant), and restored when the last
-// MaaSAuthPolicy is removed so unconfigured models remain denied.
-const gatewayDefaultAuthPolicyName = "gateway-default-auth"
+// legacyGatewayDefaultAuthPolicyName is the pre-#912 static deny AuthPolicy removed in
+// favor of maas-gateway-auth. Kept only for upgrade cleanup of stale cluster resources.
+const legacyGatewayDefaultAuthPolicyName = "gateway-default-auth"
 
 // gatewayAuthzCacheKeySelector builds the cache-key expression for gateway-level
 // model authorization checks: "userId|groups|modelIdentity".
@@ -1427,7 +1425,6 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 			return false, fmt.Errorf("failed to create gateway AuthPolicy: %w", err)
 		}
 		log.Info("gateway AuthPolicy created", "name", authPolicyName, "namespace", gatewayNamespace)
-		r.deleteGatewayDefaultAuthPolicy(ctx, log)
 		return true, nil
 	}
 
@@ -1447,14 +1444,12 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 	}
 	if specMatchesDesired(spec, currentSpec) {
 		log.Info("gateway AuthPolicy unchanged, skipping update", "name", authPolicyName)
-		r.deleteGatewayDefaultAuthPolicy(ctx, log)
 		return false, nil
 	}
 	if err := r.Update(ctx, existing); err != nil {
 		return false, fmt.Errorf("failed to update gateway AuthPolicy: %w", err)
 	}
 	log.Info("gateway AuthPolicy updated", "name", authPolicyName, "namespace", gatewayNamespace)
-	r.deleteGatewayDefaultAuthPolicy(ctx, log)
 	return true, nil
 }
 
@@ -1707,22 +1702,20 @@ func (r *MaaSAuthPolicyReconciler) handleDeletion(ctx context.Context, log logr.
 			isDefaultGateway := gatewayNs == r.GatewayNamespace && gatewayName == r.GatewayName
 			isNonDefaultTenant := tenantID != ""
 			if isNonDefaultTenant && isDefaultGateway {
-				log.Info("skipping gateway AuthPolicy cleanup: non-default tenant falling back to default gateway",
+				log.Info("skipping gateway AuthPolicy reset: non-default tenant using shared default gateway",
 					"tenantID", tenantID,
 					"tenantNamespace", policy.Namespace,
 					"gatewayNamespace", gatewayNs,
 					"gatewayName", gatewayName)
 			} else {
-				if err := r.deleteGatewayAuthPolicy(ctx, log, policy.Namespace, gatewayNs, gatewayName); err != nil {
-					log.Error(err, "failed to delete gateway AuthPolicy")
+				oidc := r.fetchOIDCConfig(ctx, log, policy.Namespace)
+				xAPIKeyEnabled := r.discoverXAPIKeyNeeded(ctx, log)
+				if _, err := r.reconcileGatewayAuthPolicy(ctx, log, "{}", oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName); err != nil {
+					log.Error(err, "failed to reset gateway auth to base version")
 					return ctrl.Result{}, err
 				}
-				if r.TenantNamespace == "" || policy.Namespace == r.TenantNamespace {
-					if err := r.ensureGatewayDefaultAuthPolicy(ctx, log); err != nil {
-						log.Error(err, "failed to restore gateway-default-auth")
-						return ctrl.Result{}, err
-					}
-				}
+				log.Info("reset maas-gateway-auth to base version (empty model access)",
+					"gatewayNamespace", gatewayNs, "gatewayName", gatewayName)
 			}
 		}
 
@@ -1734,129 +1727,54 @@ func (r *MaaSAuthPolicyReconciler) handleDeletion(ctx context.Context, log logr.
 	return ctrl.Result{}, nil
 }
 
-// deleteGatewayAuthPolicy removes the tenant's Gateway-level AuthPolicy when no
-// MaaSAuthPolicy CRs remain in that tenant namespace.
-func (r *MaaSAuthPolicyReconciler) deleteGatewayAuthPolicy(ctx context.Context, log logr.Logger, tenantNamespace, gatewayNs, gatewayName string) error {
-	// Use legacy name for default gateway (backward compatibility), dynamic name for tenant gateways
-	authPolicyName := maasGatewayAuthPolicyName
-	if gatewayNs != r.GatewayNamespace || gatewayName != r.GatewayName {
-		// This is a tenant-specific gateway, use dynamic naming
-		authPolicyName = fmt.Sprintf("%s-maas-auth", gatewayName)
+// ensureBaseGatewayAuthPolicy bootstraps maas-gateway-auth with empty model access when
+// missing. On the shared default gateway it also removes legacy gateway-default-auth left
+// over from pre-#912 clusters. Existing policies are left unchanged.
+func (r *MaaSAuthPolicyReconciler) ensureBaseGatewayAuthPolicy(
+	ctx context.Context, log logr.Logger,
+	oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, gatewayNamespace, gatewayName string,
+) error {
+	authPolicyName := r.gatewayAuthPolicyName(gatewayNamespace, gatewayName)
+	if gatewayNamespace == r.GatewayNamespace && gatewayName == r.GatewayName {
+		r.deleteLegacyGatewayDefaultAuthPolicy(ctx, log)
 	}
 
-	gwPolicy := &unstructured.Unstructured{}
-	gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	gwPolicy.SetName(authPolicyName)
-	gwPolicy.SetNamespace(gatewayNs)
-
-	if err := r.Delete(ctx, gwPolicy); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to delete gateway AuthPolicy %s/%s: %w", gatewayNs, authPolicyName, err)
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := r.Get(ctx, client.ObjectKey{Name: authPolicyName, Namespace: gatewayNamespace}, existing); err == nil {
+		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check gateway AuthPolicy %s/%s: %w", gatewayNamespace, authPolicyName, err)
 	}
-	log.Info("gateway AuthPolicy deleted (no remaining MaaSAuthPolicies)", "name", authPolicyName, "namespace", gatewayNs, "tenantNamespace", tenantNamespace)
-	return nil
+
+	_, err := r.reconcileGatewayAuthPolicy(ctx, log, "{}", oidc, xAPIKeyEnabled, tenantID, gatewayNamespace, gatewayName)
+	return err
 }
 
-// deleteGatewayDefaultAuthPolicy removes the static deny-all gateway-default-auth policy
-// so it does not conflict with the dynamic maas-gateway-auth policy on the same Gateway.
-func (r *MaaSAuthPolicyReconciler) deleteGatewayDefaultAuthPolicy(ctx context.Context, log logr.Logger) {
+func (r *MaaSAuthPolicyReconciler) deleteLegacyGatewayDefaultAuthPolicy(ctx context.Context, log logr.Logger) {
 	policy := &unstructured.Unstructured{}
 	policy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	policy.SetName(gatewayDefaultAuthPolicyName)
+	policy.SetName(legacyGatewayDefaultAuthPolicyName)
 	policy.SetNamespace(r.GatewayNamespace)
-
-	if err := r.Delete(ctx, policy); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Error(err, "failed to delete gateway-default-auth (non-fatal)", "name", gatewayDefaultAuthPolicyName)
-		}
-		return
-	}
-	log.Info("deleted gateway-default-auth (superseded by maas-gateway-auth)", "name", gatewayDefaultAuthPolicyName, "namespace", r.GatewayNamespace)
-}
-
-// ensureGatewayDefaultAuthPolicy recreates the static deny-all gateway-default-auth policy
-// after the last MaaSAuthPolicy is removed, so unconfigured model routes remain denied.
-// Management endpoints (/v1/*, /maas-api/*) are excluded so they remain accessible even
-// when no MaaSAuthPolicy CRs exist (e.g. fresh cluster with zero subscriptions).
-func (r *MaaSAuthPolicyReconciler) ensureGatewayDefaultAuthPolicy(ctx context.Context, log logr.Logger) error {
-	policy := &unstructured.Unstructured{}
-	policy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	policy.SetName(gatewayDefaultAuthPolicyName)
-	policy.SetNamespace(r.GatewayNamespace)
-
-	spec := r.gatewayDefaultAuthSpec()
 
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(policy.GroupVersionKind())
-	if err := r.Get(ctx, client.ObjectKeyFromObject(policy), existing); err == nil {
-		snapshot := existing.DeepCopy()
-		if err := unstructured.SetNestedMap(existing.Object, spec, "spec"); err != nil {
-			return fmt.Errorf("failed to set gateway-default-auth spec for update: %w", err)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(policy), existing); err != nil {
+		if apierrors.IsNotFound(err) {
+			return
 		}
-		if equality.Semantic.DeepEqual(snapshot.Object, existing.Object) {
-			log.V(1).Info("gateway-default-auth unchanged, skipping update", "name", gatewayDefaultAuthPolicyName)
-			return nil
-		}
-		if err := r.Update(ctx, existing); err != nil {
-			return fmt.Errorf("failed to update gateway-default-auth: %w", err)
-		}
-		log.Info("gateway-default-auth updated", "name", gatewayDefaultAuthPolicyName, "namespace", r.GatewayNamespace)
-		return nil
+		log.Error(err, "failed to get legacy gateway-default-auth for cleanup (non-fatal)")
+		return
 	}
-
-	policy.SetLabels(map[string]string{
-		"app.kubernetes.io/managed-by": "maas-controller",
-		"app.kubernetes.io/part-of":    "maas-controller",
-		"app.kubernetes.io/component":  "default-policy",
-	})
-	if err := unstructured.SetNestedMap(policy.Object, spec, "spec"); err != nil {
-		return fmt.Errorf("failed to set gateway-default-auth spec: %w", err)
+	if !isManaged(existing) {
+		return
 	}
-	if err := r.Create(ctx, policy); err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to create gateway-default-auth: %w", err)
+	if err := r.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "failed to delete legacy gateway-default-auth (non-fatal)")
+		return
 	}
-	log.Info("restored gateway-default-auth (no remaining MaaSAuthPolicies)", "name", gatewayDefaultAuthPolicyName, "namespace", r.GatewayNamespace)
-	return nil
-}
-
-func (r *MaaSAuthPolicyReconciler) gatewayDefaultAuthSpec() map[string]any {
-	return map[string]any{
-		"targetRef": map[string]any{
-			"group": "gateway.networking.k8s.io",
-			"kind":  "Gateway",
-			"name":  r.GatewayName,
-		},
-		"defaults": map[string]any{
-			"when": []any{
-				map[string]any{
-					"predicate": celModelIdentityAvailable,
-				},
-			},
-			"rules": map[string]any{
-				"authentication": map[string]any{},
-				"authorization": map[string]any{
-					"deny-unconfigured-models": map[string]any{
-						"metrics":  false,
-						"priority": int64(0),
-						"patternMatching": map[string]any{
-							"patterns": []any{
-								map[string]any{
-									"operator": "eq",
-									"selector": "context.request.http.method",
-									"value":    "__deny_unconfigured_models__",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	log.Info("deleted legacy gateway-default-auth (superseded by maas-gateway-auth)",
+		"name", legacyGatewayDefaultAuthPolicyName, "namespace", r.GatewayNamespace)
 }
 
 // discoverXAPIKeyNeeded lists ExternalModel CRs from inference.opendatahub.io/v1alpha1
@@ -2129,12 +2047,12 @@ func (r *MaaSAuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		), builder.WithPredicates(predicate.LabelChangedPredicate{}))
 	}
 
-	// On startup, ensure any existing gateway-default-auth has the correct
-	// spec (with when predicate). This handles upgrades from older controller
-	// versions that created the policy without management-endpoint exclusions.
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		startLog := ctrl.Log.WithName("maas-authpolicy-controller").WithValues("phase", "startup")
-		return r.ensureGatewayDefaultAuthPolicy(ctx, startLog)
+		if err := r.ensureBaseGatewayAuthPolicy(ctx, startLog, nil, false, "", r.GatewayNamespace, r.GatewayName); err != nil {
+			startLog.Error(err, "failed to ensure base maas-gateway-auth on startup (non-fatal)")
+		}
+		return nil
 	})); err != nil {
 		return err
 	}

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -850,19 +850,10 @@ func TestMaaSAuthPolicyReconciler_MultiplePoliciesDeletion(t *testing.T) {
 		},
 	}
 
-	// Pre-create gateway-default-auth (deployed by Tenant reconciler in real clusters)
-	gwDefaultAuth := &unstructured.Unstructured{}
-	gwDefaultAuth.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	gwDefaultAuth.SetName(gatewayDefaultAuthPolicyName)
-	gwDefaultAuth.SetNamespace(gatewayNS)
-	gwDefaultAuth.SetLabels(map[string]string{
-		"app.kubernetes.io/managed-by": "maas-controller",
-	})
-
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, policy1, policy2, gwDefaultAuth).
+		WithObjects(model, route, policy1, policy2).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
@@ -872,13 +863,6 @@ func TestMaaSAuthPolicyReconciler_MultiplePoliciesDeletion(t *testing.T) {
 		InfraNamespace:   "maas-system",
 		GatewayNamespace: gatewayNS,
 		GatewayName:      "maas-default-gateway",
-	}
-
-	// Verify gateway-default-auth exists before reconciliation
-	defaultAuth := &unstructured.Unstructured{}
-	defaultAuth.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	if err := c.Get(context.Background(), types.NamespacedName{Name: gatewayDefaultAuthPolicyName, Namespace: gatewayNS}, defaultAuth); err != nil {
-		t.Fatalf("gateway-default-auth should exist before reconciliation: %v", err)
 	}
 
 	// Reconcile both policies to create the aggregated AuthPolicy
@@ -896,13 +880,6 @@ func TestMaaSAuthPolicyReconciler_MultiplePoliciesDeletion(t *testing.T) {
 	authPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
 	if err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, authPolicy); err != nil {
 		t.Fatalf("gateway AuthPolicy not found before deletion: %v", err)
-	}
-
-	// Verify gateway-default-auth was DELETED (superseded by maas-gateway-auth)
-	defaultAuth = &unstructured.Unstructured{}
-	defaultAuth.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	if err := c.Get(context.Background(), types.NamespacedName{Name: gatewayDefaultAuthPolicyName, Namespace: gatewayNS}, defaultAuth); !apierrors.IsNotFound(err) {
-		t.Errorf("gateway-default-auth should be deleted when maas-gateway-auth exists, got: %v", err)
 	}
 
 	// Delete policy1 (but policy2 still exists)
@@ -925,41 +902,45 @@ func TestMaaSAuthPolicyReconciler_MultiplePoliciesDeletion(t *testing.T) {
 		t.Fatalf("Reconcile policy2 deletion: %v", err)
 	}
 
-	// Gateway AuthPolicy should NOW BE DELETED (no remaining parents).
+	// maas-gateway-auth should STILL EXIST after deleting all MaaSAuthPolicy CRs,
+	// but reset to base version with empty model access.
 	authPolicy = &unstructured.Unstructured{}
 	authPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, authPolicy)
-	if !apierrors.IsNotFound(err) {
-		t.Errorf("gateway AuthPolicy should be deleted after deleting last parent policy, but got: %v", err)
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, authPolicy); err != nil {
+		t.Fatalf("maas-gateway-auth should be kept after deleting last parent policy, but got: %v", err)
 	}
 
-	// gateway-default-auth should be RECREATED (deny-all restored for unconfigured models)
-	defaultAuth = &unstructured.Unstructured{}
-	defaultAuth.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	if err := c.Get(context.Background(), types.NamespacedName{Name: gatewayDefaultAuthPolicyName, Namespace: gatewayNS}, defaultAuth); err != nil {
-		t.Errorf("gateway-default-auth should be recreated after last MaaSAuthPolicy is deleted: %v", err)
-	}
-
-	// Verify the recreated policy scopes deny-all to model inference paths only,
-	// so management endpoints (/v1/*, /maas-api/*) remain accessible.
-	defaults, ok, _ := unstructured.NestedMap(defaultAuth.Object, "spec", "defaults")
+	// Verify the rego was reset to empty model access "{}"
+	spec, ok, _ := unstructured.NestedMap(authPolicy.Object, "spec")
 	if !ok {
-		t.Fatal("gateway-default-auth missing spec.defaults")
+		t.Fatal("maas-gateway-auth missing spec after reset")
 	}
-	whenSlice, ok, _ := unstructured.NestedSlice(defaults, "when")
-	if !ok || len(whenSlice) == 0 {
-		t.Fatal("gateway-default-auth should have a 'when' predicate to scope deny-all to model inference paths")
+	defaults, ok, _ := unstructured.NestedMap(spec, "defaults")
+	if !ok {
+		t.Fatal("maas-gateway-auth missing spec.defaults after reset")
 	}
-	whenEntry, entryOk := whenSlice[0].(map[string]any)
-	if !entryOk {
-		t.Fatal("gateway-default-auth 'when' entry is not a map")
+	rules, ok, _ := unstructured.NestedMap(defaults, "rules")
+	if !ok {
+		t.Fatal("maas-gateway-auth missing spec.defaults.rules after reset")
 	}
-	predicate, ok, _ := unstructured.NestedString(whenEntry, "predicate")
-	if !ok || predicate == "" {
-		t.Fatal("gateway-default-auth 'when' predicate should not be empty")
+	authzRules, ok, _ := unstructured.NestedMap(rules, "authorization")
+	if !ok {
+		t.Fatal("maas-gateway-auth missing authorization rules after reset")
 	}
-	if predicate != celModelIdentityAvailable {
-		t.Errorf("gateway-default-auth 'when' predicate mismatch:\ngot:  %s\nwant: %s", predicate, celModelIdentityAvailable)
+	groupMembership, ok := authzRules["require-group-membership"].(map[string]any)
+	if !ok {
+		t.Fatal("maas-gateway-auth missing require-group-membership rule after reset")
+	}
+	opa, ok := groupMembership["opa"].(map[string]any)
+	if !ok {
+		t.Fatal("require-group-membership missing opa block after reset")
+	}
+	rego, ok := opa["rego"].(string)
+	if !ok {
+		t.Fatal("require-group-membership missing rego after reset")
+	}
+	if !strings.Contains(rego, "model_access := {}") {
+		t.Errorf("rego should contain empty model_access after reset, got:\n%s", rego)
 	}
 }
 
@@ -1030,98 +1011,6 @@ func TestMaaSAuthPolicyReconciler_NonDefaultTenantDeletionPreservesSharedDefault
 	preserved.SetGroupVersionKind(sharedAuthPolicy.GroupVersionKind())
 	if err := c.Get(context.Background(), types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNamespace}, preserved); err != nil {
 		t.Fatalf("shared default gateway AuthPolicy should be preserved: %v", err)
-	}
-}
-
-// TestMaaSAuthPolicyReconciler_EnsureDefaultAuthUpgrade verifies that
-// ensureGatewayDefaultAuthPolicy updates an existing gateway-default-auth that
-// was created by an older controller version without the 'when' predicate.
-func TestMaaSAuthPolicyReconciler_EnsureDefaultAuthUpgrade(t *testing.T) {
-	const gatewayNS = "gateway-ns"
-
-	oldPolicy := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "kuadrant.io/v1",
-			"kind":       "AuthPolicy",
-			"metadata": map[string]any{
-				"name":      gatewayDefaultAuthPolicyName,
-				"namespace": gatewayNS,
-			},
-			"spec": map[string]any{
-				"targetRef": map[string]any{
-					"group": "gateway.networking.k8s.io",
-					"kind":  "Gateway",
-					"name":  "maas-gateway",
-				},
-				"defaults": map[string]any{
-					"rules": map[string]any{
-						"authentication": map[string]any{},
-						"authorization": map[string]any{
-							"deny-unconfigured-models": map[string]any{
-								"metrics":  false,
-								"priority": int64(0),
-								"patternMatching": map[string]any{
-									"patterns": []any{
-										map[string]any{
-											"operator": "eq",
-											"selector": "context.request.http.method",
-											"value":    "__deny_unconfigured_models__",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	c := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(oldPolicy).
-		Build()
-
-	rec := &MaaSAuthPolicyReconciler{
-		Client:           c,
-		GatewayNamespace: gatewayNS,
-		GatewayName:      "maas-gateway",
-	}
-
-	log := logr.Discard()
-	if err := rec.ensureGatewayDefaultAuthPolicy(context.Background(), log); err != nil {
-		t.Fatalf("ensureGatewayDefaultAuthPolicy failed: %v", err)
-	}
-
-	updated := &unstructured.Unstructured{}
-	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	if err := c.Get(context.Background(), types.NamespacedName{Name: gatewayDefaultAuthPolicyName, Namespace: gatewayNS}, updated); err != nil {
-		t.Fatalf("failed to get gateway-default-auth after update: %v", err)
-	}
-
-	defaults, ok, _ := unstructured.NestedMap(updated.Object, "spec", "defaults")
-	if !ok {
-		t.Fatal("gateway-default-auth missing spec.defaults after upgrade")
-	}
-	whenSlice, ok, _ := unstructured.NestedSlice(defaults, "when")
-	if !ok || len(whenSlice) == 0 {
-		t.Fatal("gateway-default-auth should have a 'when' predicate after upgrade")
-	}
-	whenEntry, entryOk := whenSlice[0].(map[string]any)
-	if !entryOk {
-		t.Fatal("gateway-default-auth 'when' entry is not a map")
-	}
-	predicate, ok, _ := unstructured.NestedString(whenEntry, "predicate")
-	if !ok || predicate == "" {
-		t.Fatal("gateway-default-auth 'when' predicate should not be empty after upgrade")
-	}
-	if predicate != celModelIdentityAvailable {
-		t.Errorf("gateway-default-auth 'when' predicate mismatch after upgrade:\ngot:  %s\nwant: %s", predicate, celModelIdentityAvailable)
-	}
-
-	// Calling again should be a no-op (unchanged)
-	if err := rec.ensureGatewayDefaultAuthPolicy(context.Background(), log); err != nil {
-		t.Fatalf("second call to ensureGatewayDefaultAuthPolicy failed: %v", err)
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -330,6 +330,12 @@ func (r *TenantReconciler) reconcilePlatform(
 		return &res, nil
 	}
 
+	if err := r.ensureGatewayManagementAuth(ctx, log, tenant); err != nil {
+		log.Error(err, "failed to ensure gateway management auth, will retry")
+		res := ctrl.Result{RequeueAfter: 45 * time.Second}
+		return &res, nil
+	}
+
 	surfaceReplicaWarnings(tenant, runRes)
 
 	if runRes.DeploymentPending {
@@ -602,11 +608,6 @@ func (r *TenantReconciler) cleanupTenantResources(ctx context.Context, log logr.
 			name:      tenantreconcile.MaaSAPIKeyCleanupCronJobName(tenantID),
 			namespace: appNs,
 		},
-		{
-			gvk:       tenantreconcile.GVKAuthPolicy,
-			name:      tenantreconcile.MaaSAPIAuthPolicyName(tenantID),
-			namespace: appNs,
-		},
 	}
 
 	gatewayResourcesToDelete := []struct {
@@ -761,4 +762,41 @@ func (r *TenantReconciler) cleanupMaaSAuthPolicies(ctx context.Context, log logr
 		return false, nil
 	}
 	return true, nil
+}
+
+// ensureGatewayManagementAuth bootstraps maas-gateway-auth when missing so /maas-api/*
+// management endpoints receive Authorino identity headers (RHOAIENG-81214).
+func (r *TenantReconciler) ensureGatewayManagementAuth(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.MaasTenantConfig) error {
+	tenantID, err := tenantreconcile.TenantIdentifierFor(tenant)
+	if err != nil {
+		return err
+	}
+
+	authR := &MaaSAuthPolicyReconciler{
+		Client:                          r.Client,
+		Scheme:                          r.Scheme,
+		InfraNamespace:                  r.appNamespaceForTenant(),
+		TenantNamespace:                 r.TenantNamespace,
+		GatewayName:                     r.GatewayName,
+		GatewayNamespace:                r.GatewayNamespace,
+		ClusterAudience:                 r.ClusterAudience,
+		MetadataCacheTTL:                r.MetadataCacheTTL,
+		AuthzCacheTTL:                   r.MetadataCacheTTL,
+		TenantNamespaceDiscoveryEnabled: r.TenantNamespaceDiscoveryEnabled,
+	}
+
+	gatewayNs, gatewayName, err := authR.fetchGatewayInfo(ctx, log, tenant.Namespace)
+	if err != nil {
+		return err
+	}
+	if tenantID != "" && gatewayNs == r.GatewayNamespace && gatewayName == r.GatewayName {
+		return nil
+	}
+
+	return authR.ensureBaseGatewayAuthPolicy(
+		ctx, log,
+		authR.fetchOIDCConfig(ctx, log, tenant.Namespace),
+		authR.discoverXAPIKeyNeeded(ctx, log),
+		tenantID, gatewayNs, gatewayName,
+	)
 }

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -66,7 +66,6 @@ const (
 	// Resource name base constants for multi-tenant resources.
 	// These are used with tenant identifiers to create unique resource names per tenant.
 	// For legacy/default tenant (empty tenantID), these values are used as-is.
-	baseGatewayDefaultAuthPolicyName               = "gateway-default-auth"
 	baseGatewayTokenRateLimitDefaultDenyPolicyName = "gateway-default-deny"
 	baseMaaSAPIAuthPolicyName                      = "maas-api-auth-policy"
 	baseMaaSAPIRouteName                           = "maas-api-route"
@@ -152,10 +151,6 @@ func resourceNameForTenant(baseName, tenantID string) string {
 		return baseName
 	}
 	return baseName + "-" + tenantID
-}
-
-func GatewayDefaultAuthPolicyName(tenantID string) string {
-	return resourceNameForTenant(baseGatewayDefaultAuthPolicyName, tenantID)
 }
 
 func GatewayTokenRateLimitDefaultDenyPolicyName(tenantID string) string {

--- a/test/e2e/tests/test_models_endpoint.py
+++ b/test/e2e/tests/test_models_endpoint.py
@@ -60,6 +60,7 @@ from test_helper import (
     _ns,
     _sa_to_user,
     _snapshot_cr,
+    _wait_for_gateway_auth_enforced,
     _wait_for_maas_auth_policy_phase,
     _wait_for_maas_subscription_phase,
     _wait_for_model_ready,
@@ -107,6 +108,58 @@ def _get_models_with_gateway_retry(headers, retries=GATEWAY_PROPAGATION_RETRIES)
         f"{_maas_api_url()}/v1/models",
         retries=retries,
         headers=headers,
+    )
+
+
+def _models_in_subscription(models_data, subscription_name):
+    """Return model IDs from a central /v1/models payload tied to subscription_name."""
+    models = models_data.get("data") or []
+    in_subscription = []
+    for model in models:
+        for sub in model.get("subscriptions") or []:
+            if sub.get("name") == subscription_name:
+                in_subscription.append(model.get("id"))
+                break
+    return in_subscription
+
+
+def _wait_for_central_models_in_subscription(
+    api_key,
+    subscription_name,
+    *,
+    timeout=90,
+    poll_interval=5,
+):
+    """Poll central /v1/models until at least one model is tied to subscription_name."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    deadline = time.time() + timeout
+    last_status = None
+    last_model_ids = []
+
+    while time.time() < deadline:
+        response = _get_models_with_gateway_retry(headers=headers)
+        last_status = response.status_code
+        if response.status_code != 200:
+            time.sleep(poll_interval)
+            continue
+
+        try:
+            models_data = response.json()
+        except (json.JSONDecodeError, ValueError):
+            time.sleep(poll_interval)
+            continue
+
+        in_subscription = _models_in_subscription(models_data, subscription_name)
+        if in_subscription:
+            return models_data, in_subscription
+
+        last_model_ids = [m.get("id") for m in models_data.get("data") or []]
+        time.sleep(poll_interval)
+
+    raise AssertionError(
+        f"Expected at least 1 model tied to subscription '{subscription_name}' "
+        f"within {timeout}s, but found none. "
+        f"Last HTTP status: {last_status}, returned model IDs: {last_model_ids}"
     )
 
 
@@ -2142,6 +2195,7 @@ class TestModelsEndpoint:
                 groups=["system:authenticated"]
             )
             _wait_for_maas_auth_policy_phase(auth_policy_name, timeout=90)
+            _wait_for_gateway_auth_enforced()
 
             # 2. Create subscription with low token limit
             log.info(f"Creating subscription with {token_limit} token limit")
@@ -2156,6 +2210,7 @@ class TestModelsEndpoint:
 
             # Wait for TRLP to be created and enforced
             _wait_for_token_rate_limit_policy(model_ref, model_namespace=MODEL_NAMESPACE, timeout=90)
+            _wait_for_model_ready(model_ref, namespace=MODEL_NAMESPACE, timeout=90)
 
             # 3. Create API key for this subscription.
             # Use SA token to avoid environment-specific user-token 401s.
@@ -2164,6 +2219,17 @@ class TestModelsEndpoint:
                 oc_token,
                 name=f"e2e-central-exempt-{uuid.uuid4().hex[:8]}",
                 subscription=subscription_name,
+            )
+
+            # Baseline: central discovery must list the subscription model before quota tests.
+            _, baseline_models = _wait_for_central_models_in_subscription(
+                api_key,
+                subscription_name,
+                timeout=90,
+            )
+            log.info(
+                "Central /v1/models baseline before quota exhaustion: %s",
+                baseline_models,
             )
 
             # 4. Exhaust the token limit
@@ -2198,48 +2264,28 @@ class TestModelsEndpoint:
                 f"Expected 429 for inference after exhausting tokens, got {r_inference.status_code}"
             log.info("✓ Inference endpoint correctly blocked with 429")
 
-            # 6. Verify central /v1/models endpoint still works
+            # 6-7. Verify central /v1/models still works and lists subscription models
             log.info("Verifying central /v1/models endpoint is still accessible...")
-            headers = {"Authorization": f"Bearer {api_key}"}
-            r_models = _get_models_with_gateway_retry(headers=headers)
-
-            assert r_models.status_code == 200, \
-                f"Expected 200 for central /v1/models endpoint even when quota exhausted, got {r_models.status_code}. " \
-                f"The central /v1/models endpoint should be exempt from rate limiting (gateway-level) and " \
-                f"should be able to call model-specific /v1/models endpoints (per-route exemption). " \
-                f"Response: {r_models.text[:500]}"
-
-            # 7. Verify response structure and contains our model
-            try:
-                models_data = r_models.json()
-                assert "data" in models_data, \
-                    f"Expected 'data' field in response, got: {list(models_data.keys())}"
-
-                models = models_data["data"]
-                assert isinstance(models, list), "Expected 'data' to be a list"
-
-                # Verify at least one model is tied to our test subscription
-                model_ids = [m.get("id") for m in models]
-                log.info(f"✅ Central /v1/models returned {len(models)} models: {model_ids}")
-
-                # Check that at least one model belongs to our test subscription
-                models_in_our_subscription = []
-                for model in models:
-                    # Models have a subscriptions array with subscription info
-                    model_subs = model.get("subscriptions", [])
-                    for sub in model_subs:
-                        if sub.get("name") == subscription_name:
-                            models_in_our_subscription.append(model.get("id"))
-                            break
-
-                assert len(models_in_our_subscription) >= 1, \
-                    f"Expected at least 1 model tied to subscription '{subscription_name}', " \
-                    f"but found none. Returned models: {model_ids}, subscription: {subscription_name}"
-
-                log.info(f"✓ Found {len(models_in_our_subscription)} model(s) in our subscription: {models_in_our_subscription}")
-
-            except json.JSONDecodeError as e:
-                pytest.fail(f"Central /v1/models response is not valid JSON: {e}. Response: {r_models.text[:500]}")
+            models_data, models_in_our_subscription = _wait_for_central_models_in_subscription(
+                api_key,
+                subscription_name,
+                timeout=90,
+            )
+            assert "data" in models_data, \
+                f"Expected 'data' field in response, got: {list(models_data.keys())}"
+            assert isinstance(models_data["data"], list), "Expected 'data' to be a list"
+            model_ids = [m.get("id") for m in models_data["data"]]
+            log.info(
+                "Central /v1/models returned %d models after quota exhaustion: %s",
+                len(models_data["data"]),
+                model_ids,
+            )
+            log.info(
+                "Found %d model(s) in subscription %s: %s",
+                len(models_in_our_subscription),
+                subscription_name,
+                models_in_our_subscription,
+            )
 
             log.info("✅ Central /v1/models endpoint works correctly when quota exhausted")
             log.info("   - Gateway-level exemption: ✓")

--- a/test/e2e/tests/test_per_tenant_ipp_isolation.py
+++ b/test/e2e/tests/test_per_tenant_ipp_isolation.py
@@ -55,6 +55,8 @@ from test_helper import (
     _gateway_url,
     _get_cluster_token,
     _maas_api_url,
+    _poll_status,
+    _wait_for_gateway_auth_enforced,
     _wait_reconcile,
 )
 
@@ -319,8 +321,14 @@ class TestPerTenantIPPRouting:
         default_names = per_tenant_ipp_names(DEFAULT_AITENANT_NAME)
         tenant_names = per_tenant_ipp_names(case_b["tenant_label_name"])
 
-        time.sleep(2)
+        _wait_for_gateway_auth_enforced()
         api_key = _create_default_api_key()
+        # Warm gateway allowlist after prior tests may reset maas-gateway-auth to {}.
+        warmup = _poll_status(api_key, 200, path=MODEL_PATH, timeout=90)
+        assert warmup.status_code == 200, (
+            f"Default gateway inference warmup failed: {warmup.status_code} "
+            f"{redact_sensitive(warmup.text[:500])}"
+        )
         response = _post_hybrid_chat(_gateway_url(), MODEL_PATH, api_key)
         assert response.status_code == 200, (
             f"Default gateway hybrid BBR failed: {response.status_code} "


### PR DESCRIPTION
## Summary

Cherry-pick of opendatahub-io/models-as-a-service#1333 to `rhoai-3.5`.

Fixes: [RHOAIENG-81214](https://redhat.atlassian.net/browse/RHOAIENG-81214)

After the last MaaSAuthPolicy CR is deleted (e.g. nightly test cleanup), `/maas-api/*` routes lose all authentication — requests pass through the gateway without OIDC validation or header injection.

### Root cause

When the last MaaSAuthPolicy CR is deleted, `handleDeletion` deletes `maas-gateway-auth` and creates `gateway-default-auth` as a fallback. But `gateway-default-auth` only covers model inference paths (its `celModelIdentityAvailable` predicate excludes `/maas-api/*` and `/v1/*`). Management endpoints immediately lose OIDC authentication and header injection.

### Fix

- Keep `maas-gateway-auth` in place when all MaaSAuthPolicy CRs are deleted, reset to base version with empty model access `{}`
- Add `ensureBaseGatewayAuthPolicy` — no-op if policy exists, cleans up legacy `gateway-default-auth` on upgrade
- Add `ensureGatewayManagementAuth` in tenant reconcile path as safety net
- Startup runnable ensures `maas-gateway-auth` exists on fresh install
- Requeue tenant reconcile on bootstrap failure

### Verified on cluster

Deployed on `dash-e2e-rhoai` — startup runnable created `maas-gateway-auth`, `gateway-default-auth` cleaned up, `/v1/api-keys/search` returns 200.

Upstream PR: opendatahub-io/models-as-a-service#1333

## Test plan
- [ ] Unit tests pass
- [ ] Delete last MaaSAuthPolicy → `maas-gateway-auth` stays, rego reset to `{}`
- [ ] No `gateway-default-auth` created
- [ ] Fresh startup creates base `maas-gateway-auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)