### PR TITLE
fix(RHOAIENG-81214): [rhoai-3.5] prefer HTTPS listener + prevent handleDeletion default gateway poisoning

### DIFF
--- a/maas-api/internal/tenant/handler.go
+++ b/maas-api/internal/tenant/handler.go
@@ -259,7 +259,7 @@ func selectBestListener(specListeners []any, statusByName map[string]map[string]
 			return listenerPort, listenerProtocol, listenerHostname
 		}
 
-		if !foundHTTP {
+		if listenerProtocol == protocolHTTP && !foundHTTP {
 			foundHTTP = true
 			httpPort = listenerPort
 			httpHostname = listenerHostname

--- a/maas-api/internal/tenant/handler.go
+++ b/maas-api/internal/tenant/handler.go
@@ -269,5 +269,6 @@ func selectBestListener(specListeners []any, statusByName map[string]map[string]
 	if foundHTTP {
 		return httpPort, protocolHTTP, httpHostname
 	}
+	// No ready listeners found; return safe defaults.
 	return 443, protocolHTTPS, ""
 }

--- a/maas-api/internal/tenant/handler.go
+++ b/maas-api/internal/tenant/handler.go
@@ -17,6 +17,12 @@ import (
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 )
 
+const (
+	protocolHTTPS = "HTTPS"
+	protocolTLS   = "TLS"
+	protocolHTTP  = "HTTP"
+)
+
 // Handler handles /v1/tenant endpoint requests.
 type Handler struct {
 	log              *logger.Logger
@@ -163,50 +169,7 @@ func (h *Handler) extractGatewayMetadata(gateway map[string]any) (*GatewayMetada
 		}
 	}
 
-	// Find first ready listener (has attached routes in status)
-	var port int64 = 443   // default
-	var protocol = "HTTPS" // default
-	var hostname string
-
-	for _, l := range specListenersRaw {
-		specListener, ok := l.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		// Get listener name to check status
-		listenerName, _ := specListener["name"].(string)
-		statusListener, hasStatus := statusListenersByName[listenerName]
-
-		// Check if listener is ready (has attached routes)
-		if hasStatus {
-			attachedRoutes, _ := statusListener["attachedRoutes"].(int64)
-			if attachedRoutes == 0 {
-				continue
-			}
-		} else {
-			// No status for this listener, skip
-			continue
-		}
-
-		// Extract port from spec
-		if portVal, ok := specListener["port"].(int64); ok {
-			port = portVal
-		}
-
-		// Extract protocol from spec
-		if protocolVal, ok := specListener["protocol"].(string); ok {
-			protocol = protocolVal
-		}
-
-		// Extract hostname from spec
-		if hostnameVal, ok := specListener["hostname"].(string); ok {
-			hostname = hostnameVal
-		}
-
-		// Use first ready listener
-		break
-	}
+	port, protocol, hostname := selectBestListener(specListenersRaw, statusListenersByName)
 
 	// Get external hostname from Gateway status
 	externalHost := hostname
@@ -240,7 +203,7 @@ func (h *Handler) extractGatewayMetadata(gateway map[string]any) (*GatewayMetada
 
 	// Build external URL
 	scheme := "https"
-	if protocol == "HTTP" {
+	if protocol == protocolHTTP {
 		scheme = "http"
 	}
 
@@ -257,4 +220,54 @@ func (h *Handler) extractGatewayMetadata(gateway map[string]any) (*GatewayMetada
 		ExternalURL: externalURL,
 		Port:        port,
 	}, nil
+}
+
+// selectBestListener picks the best ready listener from a Gateway spec.
+// Prefers HTTPS/TLS over HTTP to avoid redirect-induced POST→GET conversion.
+func selectBestListener(specListeners []any, statusByName map[string]map[string]any) (int64, string, string) {
+	var foundHTTP bool
+	var httpPort int64
+	var httpHostname string
+
+	for _, l := range specListeners {
+		specListener, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		listenerName, _ := specListener["name"].(string)
+		statusListener, hasStatus := statusByName[listenerName]
+		if !hasStatus {
+			continue
+		}
+		attachedRoutes, _ := statusListener["attachedRoutes"].(int64)
+		if attachedRoutes == 0 {
+			continue
+		}
+
+		listenerProtocol := protocolHTTPS
+		if protocolVal, ok := specListener["protocol"].(string); ok {
+			listenerProtocol = protocolVal
+		}
+		listenerPort := int64(443)
+		if portVal, ok := specListener["port"].(int64); ok {
+			listenerPort = portVal
+		}
+		listenerHostname, _ := specListener["hostname"].(string)
+
+		if listenerProtocol == protocolHTTPS || listenerProtocol == protocolTLS {
+			return listenerPort, listenerProtocol, listenerHostname
+		}
+
+		if !foundHTTP {
+			foundHTTP = true
+			httpPort = listenerPort
+			httpHostname = listenerHostname
+		}
+	}
+
+	if foundHTTP {
+		return httpPort, protocolHTTP, httpHostname
+	}
+	return 443, protocolHTTPS, ""
 }

--- a/maas-api/internal/tenant/handler_test.go
+++ b/maas-api/internal/tenant/handler_test.go
@@ -252,3 +252,111 @@ func TestExtractGatewayMetadata_RejectsInternalServiceName(t *testing.T) {
 	assert.Contains(t, err.Error(), "not configured with an external hostname")
 	assert.Contains(t, err.Error(), "internal service name")
 }
+
+func TestSelectBestListener_HTTPBeforeHTTPS(t *testing.T) {
+	specListeners := []any{
+		map[string]any{"name": "http", "port": int64(80), "protocol": "HTTP", "hostname": "maas.example.com"},
+		map[string]any{"name": "https", "port": int64(443), "protocol": "HTTPS", "hostname": "maas.example.com"},
+	}
+	statusByName := map[string]map[string]any{
+		"http":  {"name": "http", "attachedRoutes": int64(3)},
+		"https": {"name": "https", "attachedRoutes": int64(3)},
+	}
+
+	port, protocol, hostname := selectBestListener(specListeners, statusByName)
+
+	assert.Equal(t, int64(443), port)
+	assert.Equal(t, protocolHTTPS, protocol)
+	assert.Equal(t, "maas.example.com", hostname)
+}
+
+func TestSelectBestListener_TLSProtocol(t *testing.T) {
+	specListeners := []any{
+		map[string]any{"name": "tls", "port": int64(8443), "protocol": "TLS", "hostname": "tls.example.com"},
+	}
+	statusByName := map[string]map[string]any{
+		"tls": {"name": "tls", "attachedRoutes": int64(1)},
+	}
+
+	port, protocol, _ := selectBestListener(specListeners, statusByName)
+
+	assert.Equal(t, int64(8443), port)
+	assert.Equal(t, protocolTLS, protocol)
+}
+
+func TestSelectBestListener_HTTPOnlyWhenHTTPSNotReady(t *testing.T) {
+	specListeners := []any{
+		map[string]any{"name": "http", "port": int64(80), "protocol": "HTTP", "hostname": "maas.example.com"},
+		map[string]any{"name": "https", "port": int64(443), "protocol": "HTTPS", "hostname": "maas.example.com"},
+	}
+	statusByName := map[string]map[string]any{
+		"http":  {"name": "http", "attachedRoutes": int64(2)},
+		"https": {"name": "https", "attachedRoutes": int64(0)},
+	}
+
+	port, protocol, _ := selectBestListener(specListeners, statusByName)
+
+	assert.Equal(t, int64(80), port)
+	assert.Equal(t, protocolHTTP, protocol)
+}
+
+func TestSelectBestListener_HTTPOnlyListeners(t *testing.T) {
+	specListeners := []any{
+		map[string]any{"name": "http", "port": int64(80), "protocol": "HTTP", "hostname": "maas.example.com"},
+	}
+	statusByName := map[string]map[string]any{
+		"http": {"name": "http", "attachedRoutes": int64(1)},
+	}
+
+	port, protocol, hostname := selectBestListener(specListeners, statusByName)
+
+	assert.Equal(t, int64(80), port)
+	assert.Equal(t, protocolHTTP, protocol)
+	assert.Equal(t, "maas.example.com", hostname)
+}
+
+func TestSelectBestListener_NoReadyListeners(t *testing.T) {
+	specListeners := []any{
+		map[string]any{"name": "https", "port": int64(443), "protocol": "HTTPS"},
+	}
+	statusByName := map[string]map[string]any{
+		"https": {"name": "https", "attachedRoutes": int64(0)},
+	}
+
+	port, protocol, hostname := selectBestListener(specListeners, statusByName)
+
+	assert.Equal(t, int64(443), port)
+	assert.Equal(t, protocolHTTPS, protocol)
+	assert.Empty(t, hostname)
+}
+
+func TestSelectBestListener_IgnoresTCPListener(t *testing.T) {
+	specListeners := []any{
+		map[string]any{"name": "tcp", "port": int64(9090), "protocol": "TCP", "hostname": "tcp.example.com"},
+		map[string]any{"name": "https", "port": int64(443), "protocol": "HTTPS", "hostname": "maas.example.com"},
+	}
+	statusByName := map[string]map[string]any{
+		"tcp":   {"name": "tcp", "attachedRoutes": int64(1)},
+		"https": {"name": "https", "attachedRoutes": int64(1)},
+	}
+
+	port, protocol, hostname := selectBestListener(specListeners, statusByName)
+
+	assert.Equal(t, int64(443), port)
+	assert.Equal(t, protocolHTTPS, protocol)
+	assert.Equal(t, "maas.example.com", hostname)
+}
+
+func TestSelectBestListener_TCPOnlyNotUsedAsFallback(t *testing.T) {
+	specListeners := []any{
+		map[string]any{"name": "tcp", "port": int64(9090), "protocol": "TCP"},
+	}
+	statusByName := map[string]map[string]any{
+		"tcp": {"name": "tcp", "attachedRoutes": int64(1)},
+	}
+
+	port, protocol, _ := selectBestListener(specListeners, statusByName)
+
+	assert.Equal(t, int64(443), port)
+	assert.Equal(t, protocolHTTPS, protocol)
+}

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -1699,12 +1699,26 @@ func (r *MaaSAuthPolicyReconciler) handleDeletion(ctx context.Context, log logr.
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+
+			// Guard: when MaasTenantConfig is already gone (AITenant cascade cleanup),
+			// fetchTenantIdentifier returns "" and fetchGatewayInfo falls back to the
+			// default gateway. Without this check, the controller misidentifies the
+			// deleted non-default tenant as the default tenant and resets the default
+			// gateway's maas-gateway-auth to empty model access.
+			isDefaultTenantNamespace := r.TenantNamespace == "" || policy.Namespace == r.TenantNamespace
 			isDefaultGateway := gatewayNs == r.GatewayNamespace && gatewayName == r.GatewayName
 			isNonDefaultTenant := tenantID != ""
+
 			if isNonDefaultTenant && isDefaultGateway {
 				log.Info("skipping gateway AuthPolicy reset: non-default tenant using shared default gateway",
 					"tenantID", tenantID,
 					"tenantNamespace", policy.Namespace,
+					"gatewayNamespace", gatewayNs,
+					"gatewayName", gatewayName)
+			} else if !isDefaultTenantNamespace && !isNonDefaultTenant && isDefaultGateway {
+				log.Info("skipping gateway AuthPolicy reset: policy namespace differs from default tenant namespace (MaasTenantConfig likely already deleted)",
+					"policyNamespace", policy.Namespace,
+					"defaultTenantNamespace", r.TenantNamespace,
 					"gatewayNamespace", gatewayNs,
 					"gatewayName", gatewayName)
 			} else {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1014,6 +1014,74 @@ func TestMaaSAuthPolicyReconciler_NonDefaultTenantDeletionPreservesSharedDefault
 	}
 }
 
+// TestMaaSAuthPolicyReconciler_MisidentifiedTenantDoesNotPoisonDefaultGateway verifies
+// that when the last MaaSAuthPolicy in a non-default tenant namespace is deleted after
+// the MaasTenantConfig has been cascade-deleted, handleDeletion does NOT reset the
+// default gateway's maas-gateway-auth to empty model access.
+func TestMaaSAuthPolicyReconciler_MisidentifiedTenantDoesNotPoisonDefaultGateway(t *testing.T) {
+	const (
+		gatewayNS        = "openshift-ingress"
+		gatewayName      = "maas-default-gateway"
+		policyName       = "orphan-policy"
+		foreignNamespace = "ai-tenant-deleted-team"
+	)
+
+	// MaaSAuthPolicy in a non-default namespace with finalizer, already marked for deletion.
+	// MaasTenantConfig is NOT present (simulates AITenant cascade cleanup already ran).
+	policy := &maasv1alpha1.MaaSAuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       policyName,
+			Namespace:  foreignNamespace,
+			Finalizers: []string{maasAuthPolicyFinalizer},
+		},
+	}
+
+	// The default gateway's maas-gateway-auth with real model access (not empty).
+	gwAuth := &unstructured.Unstructured{}
+	gwAuth.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	gwAuth.SetName(maasGatewayAuthPolicyName)
+	gwAuth.SetNamespace(gatewayNS)
+	gwAuth.SetLabels(map[string]string{
+		"app.kubernetes.io/managed-by": "maas-controller",
+	})
+	_ = unstructured.SetNestedField(gwAuth.Object, "sentinel-model-access", "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(policy, gwAuth).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	if err := c.Delete(context.Background(), policy); err != nil {
+		t.Fatalf("Delete MaaSAuthPolicy: %v", err)
+	}
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		GatewayNamespace: gatewayNS,
+		GatewayName:      gatewayName,
+		TenantNamespace:  "models-as-a-service",
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: policyName, Namespace: foreignNamespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile orphan policy deletion: %v", err)
+	}
+
+	// Verify maas-gateway-auth was NOT reset — the sentinel rego should be unchanged.
+	result := &unstructured.Unstructured{}
+	result.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := c.Get(context.Background(), types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNS}, result); err != nil {
+		t.Fatalf("maas-gateway-auth should still exist: %v", err)
+	}
+	rego, _, _ := unstructured.NestedString(result.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
+	if rego != "sentinel-model-access" {
+		t.Errorf("maas-gateway-auth rego was modified (default gateway poisoned): got %q, want %q", rego, "sentinel-model-access")
+	}
+}
+
 // TestMaaSAuthPolicyReconciler_CachingConfiguration verifies that the controller
 // generates cache blocks on metadata and authorization evaluators with configurable TTLs.
 //


### PR DESCRIPTION
## Summary

Cherry-pick of opendatahub-io/models-as-a-service#1348 to `rhoai-3.5`.

Fixes: [RHOAIENG-81214](https://redhat.atlassian.net/browse/RHOAIENG-81214) (bugs 2 and 3)

### Bug 2: /v1/tenants returns http:// instead of https://

`/v1/tenants` picks the first ready listener regardless of protocol. When HTTP (port 80) is listed first, the BFF gets `http://` → POST to HTTP → 302 redirect → Go converts POST to GET → 404.

**Fix:** `selectBestListener` prefers HTTPS/TLS, falls back to HTTP only.

### Bug 3: handleDeletion poisons default gateway on tenant cleanup

When the last MaaSAuthPolicy in a non-default tenant namespace is deleted after MaasTenantConfig cascade-deleted, `fetchTenantIdentifier` returns "" and `fetchGatewayInfo` returns default gateway. Guard fails → resets default gateway to `{}`.

**Fix:** Namespace check — skip reset if policy namespace differs from default tenant namespace.

### Verified on clusters

- `ods-qe-psi-11` (3.6-ea.1): `/v1/tenants` returns `https://`, BFF zero errors
- `wenliang341-pool-fcnk4` (3.5.0): all tests pass

Upstream PR: opendatahub-io/models-as-a-service#1348

## Test plan
- [ ] Unit tests pass (7 selectBestListener + 1 misidentification guard)
- [ ] `/v1/tenants` returns `https://` URL
- [ ] BFF discovers correct URL, zero errors
- [ ] Tenant cleanup doesn't poison default gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)