### PR TITLE
fix: deny client-forged X-MaaS identity headers

### DIFF
--- a/deployment/base/maas-api/policies/auth-policy.yaml
+++ b/deployment/base/maas-api/policies/auth-policy.yaml
@@ -49,6 +49,14 @@ spec:
             expression: '{"key": request.headers.authorization.replace("Bearer ", "")}'
         priority: 0
     authorization:
+      # Reject client-supplied identity headers; Authorino injects these after auth.
+      deny-client-identity-headers:
+        metrics: false
+        priority: 0
+        patternMatching:
+          patterns:
+            - predicate: '!has(request.headers["x-maas-username"])'
+            - predicate: '!has(request.headers["x-maas-group"])'
       # Check API key is valid (only for API key auth)
       api-key-valid:
         when:


### PR DESCRIPTION
Backport the 3.4.3 AuthPolicy guard so Authorino rejects requests that supply x-maas-username / x-maas-group before trusted headers are injected.