### PR TITLE
fix: deny client-forged X-MaaS identity headers

### DIFF
--- a/deployment/base/maas-api/policies/auth-policy.yaml
+++ b/deployment/base/maas-api/policies/auth-policy.yaml
@@ -48,6 +48,15 @@ spec:
             expression: '{"key": request.headers.authorization.replace("Bearer ", "")}'
         priority: 0
     authorization:
+      # Reject client-supplied identity headers; Authorino injects these after auth.
+      deny-client-identity-headers:
+        metrics: false
+        priority: 0
+        patternMatching:
+          patterns:
+            # CEL has() only works on message fields; use `in` for map keys (Authorino).
+            - predicate: '!("x-maas-username" in request.headers)'
+            - predicate: '!("x-maas-group" in request.headers)'
       # Check API key is valid (only for API key auth)
       api-key-valid:
         when:

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -914,6 +914,22 @@ allow {
 
 	authorizationRules := map[string]any{
 		"tenant-gateway-isolation": tenantGatewayIsolationRule,
+		// Reject client-supplied identity headers; Authorino injects these after auth.
+		"deny-client-identity-headers": map[string]any{
+			"metrics":  false,
+			"priority": int64(0),
+			"patternMatching": map[string]any{
+				"patterns": []any{
+					map[string]any{
+						// CEL has() only works on message fields; use `in` for map keys.
+						"predicate": `!("x-maas-username" in request.headers)`,
+					},
+					map[string]any{
+						"predicate": `!("x-maas-group" in request.headers)`,
+					},
+				},
+			},
+		},
 		"auth-valid": map[string]any{
 			"metrics":  false,
 			"priority": int64(0),

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1750,6 +1750,40 @@ func TestBuildGatewayAuthPolicySpec_K8sAuth(t *testing.T) {
 	if _, exists := authz["oidc-groups-safe"]; exists {
 		t.Error("oidc-groups-safe should NOT be present when OIDC config is nil")
 	}
+	if _, exists := authz["deny-client-identity-headers"]; !exists {
+		t.Error("deny-client-identity-headers must be present to block forged X-MaaS identity headers")
+	}
+}
+
+func TestBuildGatewayAuthPolicySpec_DenyClientIdentityHeaders(t *testing.T) {
+	obj := gatewayAuthPolicySpecTestObject(t, nil)
+
+	patterns, found, err := unstructured.NestedSlice(
+		obj.Object,
+		"spec", "defaults", "rules", "authorization", "deny-client-identity-headers", "patternMatching", "patterns",
+	)
+	if err != nil || !found || len(patterns) != 2 {
+		t.Fatalf("deny-client-identity-headers patterns missing: found=%v len=%d err=%v", found, len(patterns), err)
+	}
+
+	got := make([]string, 0, len(patterns))
+	for i, p := range patterns {
+		m, ok := p.(map[string]any)
+		if !ok {
+			t.Fatalf("patterns[%d] is not a map: %T", i, p)
+		}
+		pred, ok := m["predicate"].(string)
+		if !ok {
+			t.Fatalf("patterns[%d] missing predicate string", i)
+		}
+		got = append(got, pred)
+	}
+
+	wantUsername := `!("x-maas-username" in request.headers)`
+	wantGroup := `!("x-maas-group" in request.headers)`
+	if got[0] != wantUsername || got[1] != wantGroup {
+		t.Fatalf("deny-client-identity-headers predicates = %#v, want [%q, %q]", got, wantUsername, wantGroup)
+	}
 }
 
 func TestBuildGatewayAuthPolicySpec_OIDCAuth(t *testing.T) {

--- a/test/e2e/tests/test_external_oidc.py
+++ b/test/e2e/tests/test_external_oidc.py
@@ -737,89 +737,86 @@ class TestOIDCAPIKeyLifecycle:
 # ---------------------------------------------------------------------------
 
 class TestOIDCHeaderInjection:
-    """Verify the gateway ignores client-supplied identity headers.
+    """Verify the gateway rejects client-supplied X-MaaS identity headers.
 
-    Authorino sets X-MaaS-Username, X-MaaS-Group, and X-MaaS-Subscription
-    from the validated token/API-key metadata. Clients must NOT be able to
-    override these by injecting the headers themselves.
+    Authorino injects X-MaaS-Username / X-MaaS-Group after auth. Clients must
+    not be able to supply those headers themselves (deny-client-identity-headers).
+    X-MaaS-Subscription spoofing is covered separately (overwrite/ignore).
     """
 
-    def test_injected_username_header_ignored(self, maas_api_base_url: str):
-        """Client-supplied X-MaaS-Username must not override the authenticated identity.
+    def test_injected_username_header_rejected(self, maas_api_base_url: str):
+        """Client-supplied X-MaaS-Username is rejected by the gateway.
 
         Mint an API key as alice_lead, then call /v1/models with a spoofed
-        X-MaaS-Username header. The request should succeed using alice's
-        real identity, not the injected one.
+        X-MaaS-Username header. deny-client-identity-headers must deny.
         """
         token = _request_oidc_token(username="alice_lead", password="letmein")
         api_key = _create_oidc_api_key(maas_api_base_url, token)["key"]
 
-        response = _oidc_request_with_retry(
-            requests.get,
+        # Unspoofed control: same credential must succeed before the deny check.
+        control = requests.get(
             f"{maas_api_base_url}/v1/models",
-            api_key,
-            label="OIDC inject X-MaaS-Username",
-            headers={"X-MaaS-Username": "evil_hacker"},
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=30,
+            verify=TLS_VERIFY,
         )
-        # The request should succeed — the spoofed header should be
-        # overwritten by Authorino with the real authenticated identity
-        assert response.status_code == 200, (
-            f"Expected 200 (injected header ignored), got {response.status_code}: {response.text}"
+        assert control.status_code == 200, (
+            f"Control /v1/models without forged headers failed: "
+            f"{control.status_code} body_bytes={len(control.content)}"
         )
-        log.info("X-MaaS-Username injection correctly ignored by gateway")
 
-    def test_injected_group_header_does_not_escalate(self, maas_api_base_url: str):
-        """Client-supplied X-MaaS-Group must not grant access to unauthorized resources.
+        response = requests.get(
+            f"{maas_api_base_url}/v1/models",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "X-MaaS-Username": "evil_hacker",
+            },
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert response.status_code in (401, 403), (
+            f"Expected 401/403 (injected header denied), "
+            f"got {response.status_code} body_bytes={len(response.content)}"
+        )
+        log.info("X-MaaS-Username injection correctly denied by gateway")
 
-        Inject a fabricated admin group and verify the request either
-        succeeds with the real groups (header overwritten) or is denied
-        (header interfered but did not grant escalated access).
-        Either outcome is safe — the critical check is that injection
-        does NOT grant broader access than the real identity.
+    def test_injected_group_header_rejected(self, maas_api_base_url: str):
+        """Client-supplied X-MaaS-Group is rejected by the gateway.
+
+        Mint an API key as alice_lead, then call /v1/models with a spoofed
+        X-MaaS-Group header. deny-client-identity-headers must deny.
         """
         token = _request_oidc_token(username="alice_lead", password="letmein")
         api_key = _create_oidc_api_key(maas_api_base_url, token)["key"]
 
-        response = _oidc_request_with_retry(
-            requests.get,
+        # Unspoofed control: same credential must succeed before the deny check.
+        control = requests.get(
             f"{maas_api_base_url}/v1/models",
-            api_key,
-            label="OIDC inject X-MaaS-Group",
-            headers={"X-MaaS-Group": '["system:cluster-admins","cluster-admin"]'},
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert control.status_code == 200, (
+            f"Control /v1/models without forged headers failed: "
+            f"{control.status_code} body_bytes={len(control.content)}"
         )
 
-        # Get baseline (no injection) for comparison
-        baseline = _oidc_request_with_retry(
-            requests.get,
+        # Raw GET — empty 403 is the expected Authorino deny and must not be
+        # retried away by _oidc_request_with_retry.
+        response = requests.get(
             f"{maas_api_base_url}/v1/models",
-            api_key,
-            label="OIDC baseline (group injection test)",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "X-MaaS-Group": '["system:cluster-admins","cluster-admin"]',
+            },
+            timeout=30,
+            verify=TLS_VERIFY,
         )
-        assert baseline.status_code == 200, (
-            f"Baseline request failed: {baseline.status_code} {baseline.text}"
+        assert response.status_code in (401, 403), (
+            f"Expected 401/403 (injected header denied), "
+            f"got {response.status_code} body_bytes={len(response.content)}"
         )
-
-        if response.status_code == 200:
-            # Header was overwritten — verify no extra models were returned
-            injected_models = response.json().get("data") or response.json().get("models") or []
-            baseline_models = baseline.json().get("data") or baseline.json().get("models") or []
-            injected_ids = sorted(m["id"] for m in injected_models)
-            baseline_ids = sorted(m["id"] for m in baseline_models)
-            assert injected_ids == baseline_ids, (
-                f"Injected X-MaaS-Group changed model list (possible escalation)! "
-                f"Baseline: {baseline_ids}, injected: {injected_ids}"
-            )
-            log.info("X-MaaS-Group injection overwritten — same models returned")
-        else:
-            # Header caused denial (e.g. 403) — safe, injection did not escalate
-            assert response.status_code in (400, 403), (
-                f"Unexpected status for injected group header: "
-                f"{response.status_code} {response.text}"
-            )
-            log.info(
-                f"X-MaaS-Group injection caused denial ({response.status_code}) "
-                f"— no escalation possible"
-            )
+        log.info("X-MaaS-Group injection correctly denied by gateway")
 
     def test_injected_subscription_header_ignored(self, maas_api_base_url: str):
         """Client-supplied X-MaaS-Subscription must not let a user access another subscription.
@@ -869,39 +866,74 @@ class TestOIDCHeaderInjection:
             f"(real subscription={real_subscription})"
         )
 
-    def test_injected_username_on_oidc_token_ignored(self, maas_api_base_url: str):
-        """Client-supplied X-MaaS-Username with a raw OIDC token (not API key) is ignored.
+    def test_injected_username_on_oidc_token_rejected(self, maas_api_base_url: str):
+        """Client-supplied X-MaaS-Username with a raw OIDC token is rejected on mint.
 
         Use a raw OIDC bearer token (not an API key) and inject a spoofed
-        username. The minted API key should still reflect the real OIDC
-        identity, not the injected header.
+        username. deny-client-identity-headers must deny before maas-api mints
+        a key, so no key material is returned.
         """
         token = _request_oidc_token(username="alice_lead", password="letmein")
 
-        # Mint an API key while injecting a spoofed username header.
-        response = _oidc_request_with_retry(
-            requests.post,
+        # Unspoofed control: same OIDC token must mint successfully first.
+        control_key_id = None
+        try:
+            control = requests.post(
+                f"{maas_api_base_url}/v1/api-keys",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                json={"name": f"e2e-oidc-control-{uuid.uuid4().hex[:8]}"},
+                timeout=30,
+                verify=TLS_VERIFY,
+            )
+            assert control.status_code in (200, 201), (
+                f"Control OIDC mint without forged headers failed: "
+                f"{control.status_code} body_bytes={len(control.content)}"
+            )
+            control_body = control.json()
+            control_key_id = control_body.get("id")
+            assert control_body.get("key", "").startswith("sk-oai-"), (
+                "Control mint missing sk-oai- key prefix"
+            )
+        finally:
+            if control_key_id:
+                _oidc_request_with_retry(
+                    requests.delete,
+                    f"{maas_api_base_url}/v1/api-keys/{control_key_id}",
+                    token,
+                    label="OIDC cleanup control mint key",
+                )
+
+        # Raw POST — empty 403 is the expected Authorino deny and must not be
+        # retried away by _oidc_request_with_retry.
+        response = requests.post(
             f"{maas_api_base_url}/v1/api-keys",
-            token,
-            label="OIDC inject test",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Content-Type": "application/json",
                 "X-MaaS-Username": "bob_sre",
             },
             json={"name": f"e2e-oidc-inject-{uuid.uuid4().hex[:8]}"},
+            timeout=30,
+            verify=TLS_VERIFY,
         )
-        assert response.status_code in (200, 201), (
-            f"API key mint with injected username header failed: "
-            f"{response.status_code} {response.text}"
+        # Avoid dumping response bodies: a regression could return a live key.
+        assert response.status_code in (401, 403), (
+            f"Expected 401/403 denying forged X-MaaS-Username on key mint, "
+            f"got {response.status_code} body_bytes={len(response.content)}"
+        )
+        assert "sk-oai-" not in response.text, (
+            "Denied mint response must not contain API key material"
+        )
+        log.info(
+            "OIDC key mint with injected X-MaaS-Username correctly denied "
+            "(status=%s body_bytes=%d)",
+            response.status_code,
+            len(response.content),
         )
 
-        data = response.json()
-        assert data.get("key", "").startswith("sk-oai-"), f"Unexpected API key payload: {data}"
-        log.info(
-            "API key minted successfully with injected X-MaaS-Username — "
-            "gateway overwrote it with real OIDC identity"
-        )
 
 
 @pytest.mark.skipif(

--- a/test/e2e/tests/test_negative_security.py
+++ b/test/e2e/tests/test_negative_security.py
@@ -2,7 +2,7 @@
 Negative-path and security-oriented E2E tests for MaaS.
 
 Validates that the platform correctly rejects abuse scenarios:
-- Header spoofing: client-supplied identity headers are stripped
+- Header spoofing: client-supplied X-MaaS identity headers are rejected at the gateway
 - Expired API keys: rejected at gateway level
 - Cross-model access: subscription-model binding enforced
 - AuthPolicy removal: access revoked when policy deleted
@@ -43,6 +43,7 @@ from test_helper import (
     UNCONFIGURED_MODEL_PATH,
     UNCONFIGURED_MODEL_REF,
     _create_api_key,
+    _create_api_key_raw,
     _create_test_auth_policy,
     _create_test_subscription,
     _delete_cr,
@@ -52,6 +53,7 @@ from test_helper import (
     _inference,
     _maas_api_url,
     _poll_status,
+    _revoke_api_key,
     _wait_for_gateway_auth_enforced,
     _wait_for_maas_auth_policy_phase,
     _wait_for_maas_subscription_phase,
@@ -65,21 +67,107 @@ log = logging.getLogger(__name__)
 # ============================================================================
 
 class TestHeaderSpoofing:
-    """Verify that client-supplied identity headers cannot influence authorization.
+    """Verify that client-supplied identity headers cannot forge authorization.
 
-    The AuthPolicy is configured to strip identity headers (X-MaaS-Username,
-    X-MaaS-Group, X-MaaS-Key-Id) before forwarding to the model backend.
-    Only X-MaaS-Subscription is injected (from key-derived identity, not client).
+    AuthPolicy deny-client-identity-headers rejects requests that already carry
+    X-MaaS-Username / X-MaaS-Group. Authorino then injects trusted identity
+    headers only after successful authentication.
 
-    Security invariant: key-derived identity always wins over client-supplied headers.
+    Security invariant: client-supplied identity headers are denied, not trusted.
     """
 
-    def test_injected_identity_headers_ignored(self):
-        """Client injects X-MaaS-Username/Group/Key-Id — platform ignores them.
+    @pytest.mark.parametrize(
+        "forged_header,label",
+        [
+            ({"X-MaaS-Username": "cluster-admin"}, "X-MaaS-Username"),
+            (
+                {"X-MaaS-Group": '["system:cluster-admins","system:masters"]'},
+                "X-MaaS-Group",
+            ),
+        ],
+        ids=["username-only", "group-only"],
+    )
+    def test_forged_identity_headers_rejected_on_key_mint(self, forged_header, label):
+        """POST /v1/api-keys with a forged X-MaaS identity header must be denied.
 
-        Validates that Authorino strips attacker-controlled identity headers.
-        The request should succeed (200) using the real key-derived identity,
-        proving the spoofed headers had no effect on authorization.
+        Each denied header is asserted independently so a regression that only
+        drops username or only drops group cannot hide behind a combined spoof.
+
+        Under deny semantics there is no spoofed key to inspect — Authorino
+        rejects before maas-api runs, so the response must not contain key
+        material. A follow-up mint without forged headers still succeeds.
+        """
+        _wait_for_gateway_auth_enforced()
+        oc_token = _get_cluster_token()
+
+        # Prove the gateway is ready for legitimate minting first.
+        # Revoke even if status/JSON assertions fail.
+        baseline_key_id = None
+        try:
+            baseline = _create_api_key_raw(oc_token, subscription=SIMULATOR_SUBSCRIPTION)
+            assert baseline.status_code in (200, 201), (
+                f"Baseline API key mint failed before spoof check: "
+                f"{baseline.status_code} body_bytes={len(baseline.content)}"
+            )
+            baseline_key_id = baseline.json().get("id")
+        finally:
+            if baseline_key_id:
+                _revoke_api_key(oc_token, baseline_key_id)
+
+        spoofed_headers = {
+            "Authorization": f"Bearer {oc_token}",
+            "Content-Type": "application/json",
+            **forged_header,
+        }
+        url = f"{_maas_api_url()}/v1/api-keys"
+        body = {
+            "name": f"e2e-spoof-mint-{uuid.uuid4().hex[:8]}",
+            "subscription": SIMULATOR_SUBSCRIPTION,
+        }
+
+        # Do not use _request_with_gateway_retry here: empty 403 is the expected
+        # Authorino deny and must not be treated as transient propagation.
+        r = requests.post(url, headers=spoofed_headers, json=body, timeout=TIMEOUT, verify=TLS_VERIFY)
+
+        # Never log response bodies from mint endpoints — a CVE regression
+        # could return a live sk-oai-* key into CI logs (CWE-532).
+        log.info(
+            "Forged %s key mint -> %s body_bytes=%d",
+            label,
+            r.status_code,
+            len(r.content),
+        )
+        assert r.status_code in (401, 403), (
+            f"Expected 401/403 denying forged {label} on key mint, "
+            f"got {r.status_code} body_bytes={len(r.content)}"
+        )
+        assert "sk-oai-" not in r.text, (
+            "Denied mint response must not contain API key material"
+        )
+
+        # Control: same token without forged headers can still mint.
+        # Revoke even if status/JSON/key-format assertions fail.
+        control_key_id = None
+        try:
+            control = _create_api_key_raw(oc_token, subscription=SIMULATOR_SUBSCRIPTION)
+            assert control.status_code in (200, 201), (
+                f"Control mint without forged headers failed: "
+                f"{control.status_code} body_bytes={len(control.content)}"
+            )
+            control_body = control.json()
+            control_key_id = control_body.get("id")
+            assert control_body.get("key", "").startswith("sk-oai-"), (
+                "Control mint missing sk-oai- key prefix"
+            )
+        finally:
+            if control_key_id:
+                _revoke_api_key(oc_token, control_key_id)
+
+    def test_injected_identity_headers_rejected_on_inference(self):
+        """Client injects X-MaaS-Username/Group — gateway rejects the request.
+
+        With deny-client-identity-headers, forged identity headers are not
+        overwritten and ignored; the request is denied at Authorino.
         """
         # Earlier tests may have rewritten maas-gateway-auth; minting a key
         # against an unenforced gateway yields empty 403 flakes.
@@ -92,16 +180,19 @@ class TestHeaderSpoofing:
             "X-MaaS-Key-Id": "fake-key-id-00000",
         }
 
-        # Shared gateway authorization state settles asynchronously between E2E cases.
-        # Require the secure steady state without failing on a brief propagation window.
-        r = _poll_status(api_key, 200, extra_headers=spoofed_headers, timeout=30)
+        r = _poll_status(api_key, (401, 403), extra_headers=spoofed_headers, timeout=30)
 
-        # Request succeeds with the REAL identity (API key owner), not the spoofed one.
-        # If spoofed headers were honored, the test user would gain cluster-admin access.
-        log.info("Spoofed identity headers -> %s", r.status_code)
-        assert r.status_code == 200, (
-            f"Expected 200 (spoofed headers stripped, real identity used), "
-            f"got {r.status_code}: {r.text[:500]}"
+        log.info(
+            "Spoofed identity headers on inference -> %s body_bytes=%d",
+            r.status_code,
+            len(r.content),
+        )
+        assert r.status_code in (401, 403), (
+            f"Expected 401/403 (forged identity headers denied), "
+            f"got {r.status_code} body_bytes={len(r.content)}"
+        )
+        assert "sk-oai-" not in r.text, (
+            "Denied inference response must not contain API key material"
         )
 
     def test_duplicate_subscription_headers_ignored(self):


### PR DESCRIPTION
## Summary
- Cherry-pick of [opendatahub-io/models-as-a-service#1365](https://github.com/opendatahub-io/models-as-a-service/pull/1365) (`9454ce8`) onto `rhoai-3.5`
- Reject client-supplied `x-maas-username` / `x-maas-group` in the gateway AuthPolicy (`buildGatewayAuthPolicySpec`) using CEL `in` predicates
- Defense-in-depth from the RHOAIENG-73109 3.4 work: create `maas-gateway-identity`, inject `X-MaaS-Gateway-Auth` via Authorino `plain.expression`, and require it on maas-api `/v1`
- Tracker: [RHOAIENG-83213](https://redhat.atlassian.net/browse/RHOAIENG-83213)

Replaces the incomplete closed PR [#700](https://github.com/red-hat-data-services/models-as-a-service/pull/700) (YAML-only).

## Test plan
- [ ] Confirm AuthPolicy rejects requests that include client-set `X-MaaS-Username` or `X-MaaS-Group`
- [ ] Confirm legitimate API-key / OIDC flows still succeed (Authorino-injected headers only)
- [ ] Confirm AuthConfigs stay Ready (CEL `in`, not `has()`)
- [ ] Confirm `maas-gateway-identity` Secret is created and `X-MaaS-Gateway-Auth` is required on `/v1` (direct pod forged-header calls fail)