### PR TITLE
fix: add gateway identity shared secret

### DIFF
--- a/deployment/base/maas-api/overlays/tls/deployment-patch.yaml
+++ b/deployment/base/maas-api/overlays/tls/deployment-patch.yaml
@@ -16,6 +16,12 @@ spec:
           value: /etc/maas-api/tls/tls.key
         - name: SSL_CERT_DIR
           value: /etc/ssl/certs:/etc/ssl/certs/openshift-service-ca
+        - name: GATEWAY_IDENTITY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: maas-gateway-identity
+              key: token
+              optional: true
         ports:
         - $patch: replace
         - containerPort: 8443

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -29,6 +29,15 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resourceNames:
+  - maas-gateway-identity
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
   resources:
   - events
   verbs:

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -236,7 +236,7 @@ func registerHandlers(
 	}
 	log.Info("Informer caches synced successfully")
 
-	v1Routes := router.Group("/v1")
+	v1Routes := router.Group("/v1", token.RequireGatewayIdentity(log, cfg.GatewayIdentityToken))
 
 	authPolicyChecker := authpolicy.NewChecker(log, cluster.MaaSAuthPolicyLister)
 	subscriptionSelector := subscription.NewSelector(log, cluster.MaaSSubscriptionLister, cluster.MaaSModelRefLister, authPolicyChecker)

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -94,6 +94,11 @@ type Config struct {
 	// Default: 1.0 (sample everything). Set lower in production for high-volume APIs.
 	OTELSampleRate float64
 
+	// GatewayIdentityToken is a shared secret injected by the gateway AuthPolicy after
+	// successful authentication. maas-api requires callers to present a matching
+	// X-MaaS-Gateway-Auth header when this value is set.
+	GatewayIdentityToken string
+
 	// Deprecated flag (backward compatibility with pre-TLS version)
 	deprecatedHTTPPort string
 }
@@ -148,6 +153,7 @@ func Load() *Config {
 		OTELEndpoint:              env.GetString("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
 		OTELInsecure:              otelInsecure,
 		OTELSampleRate:            otelSampleRate,
+		GatewayIdentityToken:      env.GetString("GATEWAY_IDENTITY_TOKEN", ""),
 		// Deprecated env var (backward compatibility with pre-TLS version)
 		deprecatedHTTPPort: env.GetString("PORT", ""),
 	}

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -13,8 +13,9 @@ const (
 	DefaultMetricsPort = 9090
 
 	// Header configuration constants.
-	HeaderUsername = "X-MaaS-Username"
-	HeaderGroup    = "X-MaaS-Group"
+	HeaderUsername    = "X-MaaS-Username"
+	HeaderGroup       = "X-MaaS-Group"
+	HeaderGatewayAuth = "X-MaaS-Gateway-Auth"
 
 	// API Key configuration defaults.
 	// DefaultAPIKeyMaxExpirationDays is the default maximum allowed expiration for API keys.

--- a/maas-api/internal/token/gateway_identity.go
+++ b/maas-api/internal/token/gateway_identity.go
@@ -1,0 +1,45 @@
+package token
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
+)
+
+// RequireGatewayIdentity rejects requests that did not pass through the gateway AuthPolicy.
+// When gatewayIdentityToken is configured, callers must present a matching
+// X-MaaS-Gateway-Auth header injected by Authorino after successful authentication.
+// Direct pod access with forged X-MaaS-Username / X-MaaS-Group headers is blocked.
+func RequireGatewayIdentity(log *logger.Logger, gatewayIdentityToken string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if gatewayIdentityToken == "" {
+			log.Warn("GATEWAY_IDENTITY_TOKEN not configured; gateway identity verification disabled")
+			c.Next()
+			return
+		}
+
+		provided := strings.TrimSpace(c.GetHeader(constant.HeaderGatewayAuth))
+		if subtle.ConstantTimeCompare([]byte(provided), []byte(gatewayIdentityToken)) != 1 {
+			log.Warn("Missing or invalid gateway identity token",
+				"header", constant.HeaderGatewayAuth,
+				"hasUsernameHeader", c.GetHeader(constant.HeaderUsername) != "",
+				"hasGroupHeader", c.GetHeader(constant.HeaderGroup) != "",
+			)
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": gin.H{
+					"type":    "authentication_error",
+					"message": "Request must be authenticated via the MaaS gateway",
+				},
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/maas-api/internal/token/gateway_identity_test.go
+++ b/maas-api/internal/token/gateway_identity_test.go
@@ -1,0 +1,109 @@
+package token_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/token"
+)
+
+const testGatewayToken = "gateway-test-secret-token"
+
+func setupGatewayProtectedRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	h := token.NewHandler(logger.Development(), "test")
+	router := gin.New()
+	router.Use(
+		token.RequireGatewayIdentity(logger.Development(), testGatewayToken),
+		h.ExtractUserInfo(),
+	)
+	router.GET("/test", func(c *gin.Context) {
+		user, exists := c.Get("user")
+		if !exists {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "user not found in context"})
+			return
+		}
+		c.JSON(http.StatusOK, user)
+	})
+
+	return router
+}
+
+func TestRequireGatewayIdentity_RejectsForgedIdentityWithoutGatewayToken(t *testing.T) {
+	router := setupGatewayProtectedRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(constant.HeaderUsername, "hacked-user")
+	req.Header.Set(constant.HeaderGroup, `["system:cluster-admins"]`)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestRequireGatewayIdentity_RejectsWrongGatewayToken(t *testing.T) {
+	router := setupGatewayProtectedRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(constant.HeaderGatewayAuth, "wrong-token")
+	req.Header.Set(constant.HeaderUsername, "alice")
+	req.Header.Set(constant.HeaderGroup, `["system:authenticated"]`)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestRequireGatewayIdentity_AllowsGatewayAuthenticatedRequest(t *testing.T) {
+	router := setupGatewayProtectedRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(constant.HeaderGatewayAuth, testGatewayToken)
+	req.Header.Set(constant.HeaderUsername, "alice")
+	req.Header.Set(constant.HeaderGroup, `["system:authenticated"]`)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var body token.UserContext
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "alice", body.Username)
+	assert.Equal(t, []string{"system:authenticated"}, body.Groups)
+}
+
+func TestRequireGatewayIdentity_SkipsVerificationWhenTokenNotConfigured(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := token.NewHandler(logger.Development(), "test")
+	router := gin.New()
+	router.Use(
+		token.RequireGatewayIdentity(logger.Development(), ""),
+		h.ExtractUserInfo(),
+	)
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(constant.HeaderUsername, "alice")
+	req.Header.Set(constant.HeaderGroup, `["system:authenticated"]`)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -944,6 +944,7 @@ func main() {
 	var observabilityManifestsPath string
 	var monitoringNamespace string
 	var usageLogsManifestPath string
+	var gatewayIdentityToken string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metrics endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -962,6 +963,8 @@ func main() {
 	flag.StringVar(&aitenantNamespace, "aitenant-namespace", tenantreconcile.DefaultAITenantNamespace, "The infrastructure namespace where AITenant CRs are accepted.")
 	flag.Int64Var(&metadataCacheTTL, "metadata-cache-ttl", 60, "TTL in seconds for Authorino metadata HTTP caching (apiKeyValidation, subscription-info).")
 	flag.Int64Var(&authzCacheTTL, "authz-cache-ttl", 60, "TTL in seconds for Authorino OPA authorization caching (auth-valid, subscription-valid, require-group-membership).")
+	flag.StringVar(&gatewayIdentityToken, "gateway-identity-token", os.Getenv("GATEWAY_IDENTITY_TOKEN"),
+		"Shared secret injected as X-MaaS-Gateway-Auth by the gateway AuthPolicy (also GATEWAY_IDENTITY_TOKEN env).")
 	flag.DurationVar(&subscriptionNamespaceMaintainInterval, "subscription-namespace-maintain-interval", 30*time.Second,
 		"How often to re-check controller-managed namespaces while the manager is running (recreate if deleted). "+
 			"Larger values reduce apiserver load; smaller values detect external deletions sooner.")
@@ -1153,6 +1156,7 @@ func main() {
 		ClusterAudience:                 clusterAudience,
 		MetadataCacheTTL:                metadataCacheTTL,
 		AuthzCacheTTL:                   authzCacheTTL,
+		GatewayIdentityToken:            gatewayIdentityToken,
 		TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
 		MaxConcurrentReconciles:         maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -86,6 +86,10 @@ type MaaSAuthPolicyReconciler struct {
 	// Applies to auth-valid, subscription-valid, and require-group-membership authorization evaluators.
 	AuthzCacheTTL int64
 
+	// GatewayIdentityToken is a shared secret injected as X-MaaS-Gateway-Auth by the gateway
+	// AuthPolicy after successful authentication. maas-api validates this header on protected routes.
+	GatewayIdentityToken string
+
 	// Recorder emits Kubernetes events for conflict detection warnings.
 	Recorder record.EventRecorder
 	// MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
@@ -1227,6 +1231,24 @@ allow {
 		},
 	}
 
+	if token := strings.TrimSpace(r.GatewayIdentityToken); token != "" {
+		if response, ok := defaultsRules["response"].(map[string]any); ok {
+			if success, ok := response["success"].(map[string]any); ok {
+				if headers, ok := success["headers"].(map[string]any); ok {
+					// Use plain.expression, not plain.value: RHCL/Kuadrant Authorino on
+					// OpenShift forwards expression-based headers but omits static plain.value.
+					headers["X-MaaS-Gateway-Auth"] = map[string]any{
+						"plain": map[string]any{
+							"expression": tenantreconcile.GatewayAuthHeaderExpression(token),
+						},
+						"metrics":  false,
+						"priority": int64(0),
+					}
+				}
+			}
+		}
+	}
+
 	return map[string]any{
 		"targetRef": map[string]any{
 			"group": "gateway.networking.k8s.io",
@@ -1370,6 +1392,12 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 ) (bool, error) {
 	log.Info("reconcileGatewayAuthPolicy entered", "gatewayNamespace", gatewayNamespace, "gatewayName", gatewayName, "tenantID", tenantID, "xAPIKeyEnabled", xAPIKeyEnabled)
 
+	gatewayToken, err := tenantreconcile.EnsureGatewayIdentityToken(ctx, r.Client, r.InfraNamespace, r.GatewayIdentityToken)
+	if err != nil {
+		return false, fmt.Errorf("failed to ensure gateway identity secret: %w", err)
+	}
+	r.GatewayIdentityToken = gatewayToken
+
 	// Calculate tenantName from tenantID
 	// Default tenant (tenantID="") uses "models-as-a-service", others use tenantID
 	tenantName := "models-as-a-service"
@@ -1398,7 +1426,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 	// the Gateway lookup.
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(gwPolicy.GroupVersionKind())
-	err := r.Get(ctx, client.ObjectKeyFromObject(gwPolicy), existing)
+	err = r.Get(ctx, client.ObjectKeyFromObject(gwPolicy), existing)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("failed to get gateway AuthPolicy: %w", err)
 	}

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1786,6 +1786,39 @@ func TestBuildGatewayAuthPolicySpec_DenyClientIdentityHeaders(t *testing.T) {
 	}
 }
 
+func TestBuildGatewayAuthPolicySpec_InjectsGatewayAuthHeader(t *testing.T) {
+	r := &MaaSAuthPolicyReconciler{
+		InfraNamespace:       "odh-ai-gateway-infra",
+		GatewayIdentityToken: "gateway-test-token",
+		MetadataCacheTTL:     60,
+		AuthzCacheTTL:        60,
+	}
+	spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	obj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+
+	headers, found, err := unstructured.NestedMap(
+		obj.Object,
+		"spec", "defaults", "rules", "response", "success", "headers",
+	)
+	if err != nil || !found {
+		t.Fatalf("response.success.headers missing: found=%v err=%v", found, err)
+	}
+	gatewayAuth, ok := headers["X-MaaS-Gateway-Auth"].(map[string]any)
+	if !ok {
+		t.Fatal("X-MaaS-Gateway-Auth header missing from gateway AuthPolicy response")
+	}
+	plain, ok := gatewayAuth["plain"].(map[string]any)
+	if !ok {
+		t.Fatalf("X-MaaS-Gateway-Auth.plain missing: %#v", gatewayAuth)
+	}
+	if plain["expression"] != "'gateway-test-token'" {
+		t.Fatalf("X-MaaS-Gateway-Auth expression = %#v, want 'gateway-test-token'", plain["expression"])
+	}
+	if _, hasValue := plain["value"]; hasValue {
+		t.Fatal("X-MaaS-Gateway-Auth must use plain.expression, not plain.value")
+	}
+}
+
 func TestBuildGatewayAuthPolicySpec_OIDCAuth(t *testing.T) {
 	oidc := &oidcConfig{
 		IssuerURL: "https://keycloak.example.com/realms/test",

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -95,6 +95,8 @@ const (
 	MaaSControllerDeploymentName = "maas-controller"
 	MaaSDBSecretName             = "maas-db-config" //nolint:gosec // secret name reference, not a credential
 	MaaSDBSecretKey              = "DB_CONNECTION_URL"
+	MaaSGatewayIdentitySecretName = "maas-gateway-identity" //nolint:gosec // secret name reference, not a credential
+	MaaSGatewayIdentitySecretKey  = "token"
 
 	// Condition types aligned with ODH internal/controller/status for DSC aggregation parity.
 	ConditionDependenciesAvailable      = "DependenciesAvailable"

--- a/maas-controller/pkg/platform/tenantreconcile/gateway_identity_secret.go
+++ b/maas-controller/pkg/platform/tenantreconcile/gateway_identity_secret.go
@@ -1,0 +1,98 @@
+package tenantreconcile
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const gatewayIdentityTokenBytes = 32
+
+// EnsureGatewayIdentityToken returns the shared gateway identity token used to
+// inject and validate X-MaaS-Gateway-Auth. When the secret does not exist it is
+// created automatically in the application/infra namespace.
+//
+// RBAC uses get + create on resourceNames=maas-gateway-identity only. Kubernetes
+// does not scope list/watch by resourceNames, so get is used to read that single
+// secret instance without listing other secrets in the namespace.
+func EnsureGatewayIdentityToken(ctx context.Context, c client.Client, namespace, configuredToken string) (string, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return "", fmt.Errorf("application namespace is required to ensure gateway identity secret")
+	}
+
+	secretName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      MaaSGatewayIdentitySecretName,
+	}
+
+	existing := &corev1.Secret{}
+	err := c.Get(ctx, secretName, existing)
+	switch {
+	case err == nil:
+		token := strings.TrimSpace(string(existing.Data[MaaSGatewayIdentitySecretKey]))
+		if token == "" {
+			return "", fmt.Errorf("gateway identity secret %s exists but %q is empty",
+				secretName, MaaSGatewayIdentitySecretKey)
+		}
+		return token, nil
+	case apierrors.IsNotFound(err):
+		token := strings.TrimSpace(configuredToken)
+		if token == "" {
+			var genErr error
+			token, genErr = generateGatewayIdentityToken()
+			if genErr != nil {
+				return "", genErr
+			}
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName.Name,
+				Namespace: secretName.Namespace,
+				Labels: map[string]string{
+					"app":                          "maas-api",
+					"app.kubernetes.io/managed-by": "maas-controller",
+					"app.kubernetes.io/part-of":    "maas-gateway-auth",
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				MaaSGatewayIdentitySecretKey: []byte(token),
+			},
+		}
+		if err := c.Create(ctx, secret); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return EnsureGatewayIdentityToken(ctx, c, namespace, configuredToken)
+			}
+			return "", fmt.Errorf("failed to create gateway identity secret %s: %w", secretName, err)
+		}
+		return token, nil
+	default:
+		return "", fmt.Errorf("failed to get gateway identity secret %s: %w", secretName, err)
+	}
+}
+
+func generateGatewayIdentityToken() (string, error) {
+	buf := make([]byte, gatewayIdentityTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("failed to generate gateway identity token: %w", err)
+	}
+	// URL-safe base64 without padding; matches openssl-based deploy scripts.
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// GatewayAuthHeaderExpression returns an Authorino plain.expression that injects
+// the shared gateway identity token. Prefer expression over plain.value: RHCL/Kuadrant
+// Authorino on OpenShift forwards selector/expression-based headers upstream but
+// omits static plain.value.
+func GatewayAuthHeaderExpression(token string) string {
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(token, "'", "\\'"))
+}

--- a/maas-controller/pkg/platform/tenantreconcile/gateway_identity_secret_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/gateway_identity_secret_test.go
@@ -1,0 +1,81 @@
+package tenantreconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, maasv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestEnsureGatewayIdentityToken_CreatesSecretWhenMissing(t *testing.T) {
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	token, err := EnsureGatewayIdentityToken(ctx, c, "opendatahub", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	secret := &corev1.Secret{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{
+		Namespace: "opendatahub",
+		Name:      MaaSGatewayIdentitySecretName,
+	}, secret))
+	assert.Equal(t, []byte(token), secret.Data[MaaSGatewayIdentitySecretKey])
+	assert.Equal(t, "maas-controller", secret.Labels["app.kubernetes.io/managed-by"])
+}
+
+func TestEnsureGatewayIdentityToken_UsesConfiguredTokenOnCreate(t *testing.T) {
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	token, err := EnsureGatewayIdentityToken(ctx, c, "opendatahub", "configured-token")
+	require.NoError(t, err)
+	assert.Equal(t, "configured-token", token)
+
+	secret := &corev1.Secret{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{
+		Namespace: "opendatahub",
+		Name:      MaaSGatewayIdentitySecretName,
+	}, secret))
+	assert.Equal(t, []byte("configured-token"), secret.Data[MaaSGatewayIdentitySecretKey])
+}
+
+func TestEnsureGatewayIdentityToken_ReturnsExistingSecret(t *testing.T) {
+	ctx := context.Background()
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      MaaSGatewayIdentitySecretName,
+			Namespace: "opendatahub",
+		},
+		Data: map[string][]byte{
+			MaaSGatewayIdentitySecretKey: []byte("existing-token"),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(existing).Build()
+
+	token, err := EnsureGatewayIdentityToken(ctx, c, "opendatahub", "configured-token")
+	require.NoError(t, err)
+	assert.Equal(t, "existing-token", token)
+}
+
+func TestGatewayAuthHeaderExpression_EscapesQuotes(t *testing.T) {
+	assert.Equal(t, "'gateway-test-token'", GatewayAuthHeaderExpression("gateway-test-token"))
+	assert.Equal(t, `'tok\'en'`, GatewayAuthHeaderExpression("tok'en"))
+}

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -89,6 +90,12 @@ func RunPlatform(
 	resources, err := PostRender(ctx, log, tenant, rendered, params)
 	if err != nil {
 		return nil, fmt.Errorf("post-render: %w", err)
+	}
+
+	// Ensure the shared gateway identity secret exists before maas-api pods start
+	// so GATEWAY_IDENTITY_TOKEN can be mounted from maas-gateway-identity.
+	if _, err := EnsureGatewayIdentityToken(ctx, c, appNs, os.Getenv("GATEWAY_IDENTITY_TOKEN")); err != nil {
+		return nil, fmt.Errorf("gateway identity secret: %w", err)
 	}
 
 	if err := ApplyRendered(ctx, c, scheme, tenant, appNs, mcfg, resources); err != nil {


### PR DESCRIPTION
## Summary
- Port the RHOAIENG-73109 / 3.4 gateway-identity defense-in-depth onto `rhoai-3.5` (follow-up to merged [#702](https://github.com/red-hat-data-services/models-as-a-service/pull/702))
- Create `maas-gateway-identity`, inject `X-MaaS-Gateway-Auth` from `buildGatewayAuthPolicySpec` via Authorino `plain.expression`, and require it on maas-api `/v1`
- Complements `deny-client-identity-headers` by blocking forged identity headers on direct maas-api access
- Tracker: [RHOAIENG-83213](https://redhat.atlassian.net/browse/RHOAIENG-83213)

## Test plan
- [ ] Confirm `maas-gateway-identity` Secret is created in the infra namespace
- [ ] Confirm gateway AuthPolicy injects `X-MaaS-Gateway-Auth` (`plain.expression`, not `plain.value`)
- [ ] Confirm `/v1` rejects requests missing/wrong gateway auth token; `/internal/v1` remains reachable for Authorino
- [ ] Confirm legitimate gateway-authenticated mint/list flows still succeed


Made with [Cursor](https://cursor.com)