### PR TITLE
fix: auto-label infra namespace with gateway selector matchLabels

### DIFF
--- a/docs/content/configuration-and-management/gateway-patterns.md
+++ b/docs/content/configuration-and-management/gateway-patterns.md
@@ -218,7 +218,17 @@ spec:
 
 #### 5. HTTPRoute
 
-Attach workloads to the Gateway. This example routes all traffic to `maas-api`:
+Attach workloads to the Gateway. The Gateway `allowedRoutes` uses a label selector.
+The controller automatically labels the infrastructure namespace (see
+[Automatic infrastructure namespace labeling](#automatic-infrastructure-namespace-labeling)).
+Label any additional namespaces (e.g. model namespaces) manually:
+
+```bash
+# Label model namespaces that need to attach HTTPRoutes
+oc label namespace <model-namespace> maas.opendatahub.io/gateway-access=true --overwrite
+```
+
+This example routes all traffic to `maas-api`:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -316,6 +326,66 @@ kubectl get secret maas-gw-service-tls -n openshift-ingress
 | `503` from the Route | Gateway Service not ready or certificate not yet provisioned | Wait for `service-ca-operator` to provision `maas-gw-service-tls`; check `kubectl get secret -n openshift-ingress` |
 | TLS handshake failure (re-encrypt) | Service CA cert not trusted by the Router | Ensure `tls.destinationCACertificate` contains the service CA bundle from `signing-cabundle` ConfigMap in `openshift-service-ca` namespace |
 | `certificateRefs` name mismatch | Secret name in Gateway does not match ConfigMap annotation | Verify both reference the same Secret name (`maas-gw-service-tls`) |
+
+## Automatic infrastructure namespace labeling
+
+When a Gateway uses `allowedRoutes.namespaces.from: Selector` with `matchLabels`,
+the MaaS controller automatically applies those labels to the infrastructure
+namespace (where `maas-api-route` HTTPRoutes live). This ensures the Gateway
+accepts MaaS API routes without manual labeling of the infra namespace.
+
+Model namespaces still require manual labeling — the controller only manages the
+infrastructure namespace.
+
+### How it works
+
+Each time an AITenant is reconciled, the controller reads the Gateway's listener
+`matchLabels` and applies them to the infra namespace. An annotation
+(`maas.opendatahub.io/gateway-selector-labels`) tracks which gateway owns each
+label so that labels can be cleaned up when a tenant is deleted or a gateway's
+selector changes.
+
+When multiple gateways share the same label (e.g. both use
+`maas-gateway-access=true`), all are recorded as co-owners. Deleting one
+tenant does not remove a label that another tenant's gateway still requires.
+
+The controller also watches for Gateway spec changes and re-reconciles the
+affected AITenants automatically.
+
+### Conflict errors
+
+Two situations produce reconciliation errors visible in the AITenant status
+(condition `type: Degraded`, `reason: InfraNamespaceLabelFailed`):
+
+**Intra-gateway conflict:** A single gateway has two listeners that disagree on a
+label value (e.g. listener `https` wants `env=prod` and listener `https-alt`
+wants `env=staging`). Fix the gateway so all listeners use the same value for
+each label key.
+
+**Cross-gateway conflict:** Two gateways want different values for the same label
+key. For example, gateway-a set `env=prod` and gateway-b wants `env=staging`.
+Use distinct label keys per gateway (e.g. `gateway-a-access=true` and
+`gateway-b-access=true`) or ensure both use the same value.
+
+A co-owner cannot change a shared label's value while other gateways still
+depend on the current value. The conflicting tenant's AITenant status reports
+which gateway owns the contested label.
+
+### Limitations
+
+- Only `matchLabels` is supported. Gateways using `matchExpressions` require
+  manual namespace configuration.
+- The controller does not label model namespaces — only the infrastructure
+  namespace.
+- Labels not selected by any managed Gateway are not tracked in the ownership
+  annotation. The controller does not manage or clean up those labels. Remove
+  them manually if they are no longer needed:
+  ```bash
+  oc label namespace <infra-namespace> <label-key>-
+  ```
+- If an existing label on the infrastructure namespace conflicts with a
+  gateway's desired value, the controller rejects the reconciliation rather
+  than overwriting it. Resolve the conflict manually before retrying.
 
 ## MaaS integration
 

--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -18,9 +18,10 @@ Each AITenant requires a dedicated Gateway. Gateways cannot be shared between AI
 Get the cluster domain and create the Gateway.
 
 The Gateway uses a per-tenant label selector for `allowedRoutes` so only explicitly
-labelled namespaces can attach HTTPRoutes — more secure than `from: All`. Label each
-namespace that needs access (infra namespace, model namespaces) before or after Gateway
-creation:
+labelled namespaces can attach HTTPRoutes. The controller automatically labels
+the infrastructure namespace with the gateway's `matchLabels` (see
+[Automatic infrastructure namespace labeling](../configuration-and-management/gateway-patterns.md#automatic-infrastructure-namespace-labeling)).
+Model namespaces still require manual labeling.
 
 ```bash
 TENANT_NAME="red-team"
@@ -30,11 +31,8 @@ GATEWAY_NAMESPACE="openshift-ingress"
 CERT_NAME="router-certs-default"
 GATEWAY_ACCESS_LABEL="maas.opendatahub.io/gateway-access-${TENANT_NAME}"
 
-# Label the namespaces that need to attach HTTPRoutes to this tenant Gateway.
-# At minimum: the infrastructure namespace where maas-api is deployed.
-# Also label any model namespaces (e.g. llm) where LLMInferenceServices run.
-INFRA_NS="odh-ai-gateway-infra"   # adjust if using RHOAI (redhat-ai-gateway-infra)
-oc label namespace "${INFRA_NS}" "${GATEWAY_ACCESS_LABEL}=true" --overwrite
+# Label model namespaces that need to attach HTTPRoutes to this tenant Gateway.
+# The infrastructure namespace is labeled automatically by the controller.
 # oc label namespace llm "${GATEWAY_ACCESS_LABEL}=true" --overwrite  # repeat for model namespaces
 
 cat <<EOF | oc apply -f -
@@ -125,17 +123,16 @@ oc get gateway ${TENANT_NAME} -n ${GATEWAY_NAMESPACE}
 ```
 
 !!! tip "Automated script"
-    The `scripts/create-ai-tenant.sh` script automates Gateway, Route, and AITenant creation.
-    For multi-tenant deployments use the per-gateway label selector and label namespaces manually:
+    The `scripts/create-ai-tenant.sh` script automates Gateway and AITenant creation.
+    For multi-tenant deployments use the per-gateway label selector:
     ```bash
     NAMESPACE_SELECTOR_LABELS="maas.opendatahub.io/gateway-access-red-team=true" \
       ./scripts/create-ai-tenant.sh red-team
     ```
-    Then label the infra namespace and any model namespaces:
+    The controller labels the infrastructure namespace automatically. Label any
+    model namespaces manually:
     ```bash
-    oc label namespace odh-ai-gateway-infra \
-      maas.opendatahub.io/gateway-access-red-team=true --overwrite
-    # oc label namespace llm maas.opendatahub.io/gateway-access-red-team=true --overwrite
+    oc label namespace llm maas.opendatahub.io/gateway-access-red-team=true --overwrite
     ```
 
 ## 2. Create the AITenant CR

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -70,6 +72,8 @@ const (
 
 	aitenantAPIKeysRevokedAnnotation = "maas.opendatahub.io/api-keys-revoked" //nolint:gosec // Annotation name, not a credential.
 	aitenantAPIKeysRevokedCondition  = "APIKeysRevoked"
+
+	gatewayLabelsAnnotation = "maas.opendatahub.io/gateway-selector-labels"
 
 	aitenantAPIKeyCleanupServiceAccountName = "maas-api-cleanup"
 	aitenantAPIKeyCleanupCABundleName       = "openshift-service-ca.crt"         //nolint:gosec // ConfigMap name for a public CA bundle, not a credential.
@@ -210,12 +214,27 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	if err := r.validateTenantGateway(ctx, gatewayRef); err != nil {
+	gw, err := r.validateTenantGateway(ctx, gatewayRef)
+	if err != nil {
 		setAITenantPhase(&aitenant, "Failed", "GatewayCheckFailed", err.Error())
 		if err2 := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err2 != nil {
 			return ctrl.Result{}, err2
 		}
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	if err := r.ensureInfraNamespaceGatewayLabels(ctx, gw); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "infra namespace gateway label reconciliation failed, continuing")
+		apimeta.SetStatusCondition(&aitenant.Status.Conditions, metav1.Condition{
+			Type:               tenantreconcile.ConditionTypeDegraded,
+			Status:             metav1.ConditionTrue,
+			Reason:             "InfraNamespaceLabelFailed",
+			Message:            err.Error(),
+			ObservedGeneration: aitenant.Generation,
+			LastTransitionTime: metav1.Now(),
+		})
+	} else {
+		apimeta.RemoveStatusCondition(&aitenant.Status.Conditions, tenantreconcile.ConditionTypeDegraded)
 	}
 
 	if err := r.ensureGatewayClaim(ctx, &aitenant, gatewayRef); err != nil {
@@ -267,6 +286,11 @@ func (r *AITenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&maasv1alpha1.MaasTenantConfig{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueAITenantForTenantConfig),
+		).
+		Watches(
+			&gatewayapiv1.Gateway{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueAITenantForGateway),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Complete(r)
 }
@@ -373,22 +397,186 @@ func (r *AITenantReconciler) ensureTenantNamespace(ctx context.Context, aitenant
 	return false, nil
 }
 
-func (r *AITenantReconciler) validateTenantGateway(ctx context.Context, ref maasv1alpha1.TenantGatewayRef) error {
+func (r *AITenantReconciler) validateTenantGateway(ctx context.Context, ref maasv1alpha1.TenantGatewayRef) (*gatewayapiv1.Gateway, error) {
 	if ref.Namespace == "" {
-		return errors.New("gateway namespace is required; set --gateway-namespace")
+		return nil, errors.New("gateway namespace is required; set --gateway-namespace")
 	}
 	if ref.Name == "" {
-		return errors.New("spec.gateway.name is required when AITenant name is empty")
+		return nil, errors.New("spec.gateway.name is required when AITenant name is empty")
 	}
 
 	var gateway gatewayapiv1.Gateway
 	key := client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
 	if err := r.get(ctx, key, &gateway); err != nil {
 		if isNotFoundError(err) {
-			return fmt.Errorf("gateway %s/%s not found: the Gateway must be created by a network or cluster administrator before AITenant can be provisioned", key.Namespace, key.Name)
+			return nil, fmt.Errorf("gateway %s/%s not found: the Gateway must be created by a network or cluster administrator before AITenant can be provisioned", key.Namespace, key.Name)
 		}
-		return fmt.Errorf("get Gateway %s/%s: %w", key.Namespace, key.Name, err)
+		return nil, fmt.Errorf("get Gateway %s/%s: %w", key.Namespace, key.Name, err)
 	}
+	return &gateway, nil
+}
+
+// parseOwnershipAnnotation parses the gateway-selector-labels annotation.
+func parseOwnershipAnnotation(raw string) (map[string][]string, error) {
+	if raw == "" {
+		return map[string][]string{}, nil
+	}
+	var ownership map[string][]string
+	if err := json.Unmarshal([]byte(raw), &ownership); err != nil {
+		return nil, err
+	}
+	return ownership, nil
+}
+
+// gatewayDesiredLabels extracts the union of matchLabels from all listeners
+// that use namespace-selector routing. Returns an error if two listeners on
+// the same gateway disagree on a label value.
+func gatewayDesiredLabels(gw *gatewayapiv1.Gateway) (map[string]string, error) {
+	desired := map[string]string{}
+	for _, listener := range gw.Spec.Listeners {
+		if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
+			continue
+		}
+		ns := listener.AllowedRoutes.Namespaces
+		if ns.From == nil || *ns.From != gatewayapiv1.NamespacesFromSelector || ns.Selector == nil {
+			continue
+		}
+		for k, v := range ns.Selector.MatchLabels {
+			if existing, ok := desired[k]; ok && existing != v {
+				return nil, fmt.Errorf("gateway %s/%s has conflicting namespace selector values for label %q: listener %q wants %q but another listener wants %q",
+					gw.Namespace, gw.Name, k, listener.Name, v, existing)
+			}
+			desired[k] = v
+		}
+	}
+	return desired, nil
+}
+
+// ensureInfraNamespaceGatewayLabels applies the gateway's listener matchLabels
+// to the shared infrastructure namespace so that hardened gateways accept
+// per-tenant maas-api HTTPRoutes from it. It tracks label ownership via an
+// annotation to detect cross-gateway conflicts and remove stale labels when a
+// gateway's selector changes.
+func (r *AITenantReconciler) ensureInfraNamespaceGatewayLabels(ctx context.Context, gw *gatewayapiv1.Gateway) error {
+	desiredLabels, err := gatewayDesiredLabels(gw)
+	if err != nil {
+		return err
+	}
+
+	var infraNs corev1.Namespace
+	if err := r.get(ctx, client.ObjectKey{Name: r.AppNamespace}, &infraNs); err != nil {
+		if isNotFoundError(err) && len(desiredLabels) == 0 {
+			return nil
+		}
+		return fmt.Errorf("read infra namespace %s: %w", r.AppNamespace, err)
+	}
+
+	ownership, err := parseOwnershipAnnotation(infraNs.Annotations[gatewayLabelsAnnotation])
+	if err != nil {
+		return fmt.Errorf("unmarshal %s annotation on infra namespace %s: %w", gatewayLabelsAnnotation, r.AppNamespace, err)
+	}
+
+	// Conflict detection: reject if the desired value differs from an existing
+	// value that is either owned by another gateway or set out of band.
+	for k, v := range desiredLabels {
+		existing, present := infraNs.Labels[k]
+		if !present || existing == v {
+			continue
+		}
+		owners := ownership[k]
+		if len(owners) == 0 {
+			return fmt.Errorf("label %q on infra namespace %s already has value %q set outside the controller; gateway %q wants %q — resolve manually",
+				k, r.AppNamespace, existing, gw.Name, v)
+		}
+		otherOwners := len(owners) > 1 || owners[0] != gw.Name
+		if otherOwners {
+			otherName := owners[0]
+			if otherName == gw.Name && len(owners) > 1 {
+				otherName = owners[1]
+			}
+			return fmt.Errorf("conflicting gateway label %q on infra namespace %s: owned by gateway %q (value %q) but gateway %q wants %q",
+				k, r.AppNamespace, otherName, existing, gw.Name, v)
+		}
+	}
+
+	// Compute stale labels: keys owned by THIS gateway that are no longer desired.
+	var staleKeys []string
+	for k, owners := range ownership {
+		if !slices.Contains(owners, gw.Name) {
+			continue
+		}
+		if _, stillDesired := desiredLabels[k]; !stillDesired {
+			staleKeys = append(staleKeys, k)
+		}
+	}
+
+	// Check whether a patch is needed.
+	needsPatch := len(staleKeys) > 0
+	if !needsPatch {
+		for k, v := range desiredLabels {
+			if infraNs.Labels[k] != v {
+				needsPatch = true
+				break
+			}
+		}
+	}
+	if !needsPatch {
+		// Ensure the ownership annotation is up to date even when labels match.
+		ownershipChanged := false
+		for k := range desiredLabels {
+			if !slices.Contains(ownership[k], gw.Name) {
+				ownershipChanged = true
+				break
+			}
+		}
+		if !ownershipChanged {
+			return nil
+		}
+	}
+
+	// Build the patch: add desired labels, remove stale labels, update annotation.
+	// Use optimistic locking so concurrent reconciles for different tenants
+	// get a 409 Conflict instead of silently overwriting each other's ownership.
+	patch := client.MergeFromWithOptions(infraNs.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	if infraNs.Labels == nil {
+		infraNs.Labels = make(map[string]string)
+	}
+	for k, v := range desiredLabels {
+		infraNs.Labels[k] = v
+		if !slices.Contains(ownership[k], gw.Name) {
+			ownership[k] = append(ownership[k], gw.Name)
+		}
+	}
+	for _, k := range staleKeys {
+		ownership[k] = slices.DeleteFunc(ownership[k], func(s string) bool { return s == gw.Name })
+		if len(ownership[k]) == 0 {
+			delete(infraNs.Labels, k)
+			delete(ownership, k)
+		}
+	}
+
+	// Serialize updated ownership annotation.
+	if infraNs.Annotations == nil {
+		infraNs.Annotations = make(map[string]string)
+	}
+	if len(ownership) == 0 {
+		delete(infraNs.Annotations, gatewayLabelsAnnotation)
+	} else {
+		ownershipJSON, err := json.Marshal(ownership)
+		if err != nil {
+			return fmt.Errorf("marshal %s annotation: %w", gatewayLabelsAnnotation, err)
+		}
+		infraNs.Annotations[gatewayLabelsAnnotation] = string(ownershipJSON)
+	}
+
+	if err := r.Patch(ctx, &infraNs, patch); err != nil {
+		return fmt.Errorf("patch labels on infra namespace %s: %w", r.AppNamespace, err)
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("applied gateway namespace-selector labels to infrastructure namespace",
+		"infraNamespace", r.AppNamespace, "gateway", gw.Name,
+		"applied", desiredLabels, "removed", staleKeys)
 	return nil
 }
 
@@ -403,6 +591,106 @@ func (r *AITenantReconciler) gatewayRefFor(aitenant *maasv1alpha1.AITenant) maas
 		}
 	}
 	return ref
+}
+
+// cleanupGatewayLabelsOnDelete removes labels from the infrastructure namespace
+// that were applied by the gateway belonging to the deleted AITenant.
+func (r *AITenantReconciler) cleanupGatewayLabelsOnDelete(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {
+	gatewayRef := r.gatewayRefFor(aitenant)
+	if gatewayRef.Name == "" || gatewayRef.Namespace == "" {
+		return nil
+	}
+
+	var infraNs corev1.Namespace
+	if err := r.get(ctx, client.ObjectKey{Name: r.AppNamespace}, &infraNs); err != nil {
+		if isNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("read infra namespace %s: %w", r.AppNamespace, err)
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	ownership, err := parseOwnershipAnnotation(infraNs.Annotations[gatewayLabelsAnnotation])
+	if err != nil {
+		log.Error(err, "failed to parse gateway label ownership annotation, skipping label cleanup",
+			"infraNamespace", r.AppNamespace, "gateway", gatewayRef.Name)
+		return nil
+	}
+
+	// Find label keys owned (or co-owned) by the deleted tenant's gateway.
+	var keysToRemove []string
+	var keysToUnown []string
+	for k, owners := range ownership {
+		if !slices.Contains(owners, gatewayRef.Name) {
+			continue
+		}
+		if len(owners) == 1 {
+			keysToRemove = append(keysToRemove, k)
+		} else {
+			keysToUnown = append(keysToUnown, k)
+		}
+	}
+	if len(keysToRemove) == 0 && len(keysToUnown) == 0 {
+		return nil
+	}
+
+	patch := client.MergeFromWithOptions(infraNs.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	for _, k := range keysToRemove {
+		delete(infraNs.Labels, k)
+		delete(ownership, k)
+	}
+	for _, k := range keysToUnown {
+		ownership[k] = slices.DeleteFunc(ownership[k], func(s string) bool { return s == gatewayRef.Name })
+	}
+	if infraNs.Annotations == nil {
+		infraNs.Annotations = make(map[string]string)
+	}
+	if len(ownership) == 0 {
+		delete(infraNs.Annotations, gatewayLabelsAnnotation)
+	} else {
+		ownershipJSON, err := json.Marshal(ownership)
+		if err != nil {
+			log.Error(err, "failed to marshal gateway label ownership annotation, skipping label cleanup",
+				"infraNamespace", r.AppNamespace, "gateway", gatewayRef.Name)
+			return nil
+		}
+		infraNs.Annotations[gatewayLabelsAnnotation] = string(ownershipJSON)
+	}
+
+	if err := r.Patch(ctx, &infraNs, patch); err != nil {
+		return fmt.Errorf("cleanup gateway labels on infra namespace %s: %w", r.AppNamespace, err)
+	}
+
+	log.Info("cleaned up gateway namespace-selector labels from infrastructure namespace",
+		"infraNamespace", r.AppNamespace, "gateway", gatewayRef.Name,
+		"removed", keysToRemove, "unowned", keysToUnown)
+	return nil
+}
+
+// enqueueAITenantForGateway maps Gateway events back to the AITenants that
+// reference them. This ensures that changes to a Gateway's allowedRoutes
+// selector are reflected on the infrastructure namespace labels.
+func (r *AITenantReconciler) enqueueAITenantForGateway(ctx context.Context, obj client.Object) []reconcile.Request {
+	var list maasv1alpha1.AITenantList
+	if err := r.APIReader.List(ctx, &list, client.InNamespace(r.aitenantNamespace())); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list AITenants for gateway mapper")
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range list.Items {
+		ref := r.gatewayRefFor(&list.Items[i])
+		if ref.Name == obj.GetName() && ref.Namespace == obj.GetNamespace() {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      list.Items[i].Name,
+					Namespace: list.Items[i].Namespace,
+				},
+			})
+		}
+	}
+	return requests
 }
 
 func (r *AITenantReconciler) migrateLegacyTenantPlatformContext(ctx context.Context, aitenant *maasv1alpha1.AITenant, tenantNamespace string) (bool, error) {
@@ -667,6 +955,10 @@ func (r *AITenantReconciler) reconcileAITenantDelete(ctx context.Context, aitena
 		return ctrl.Result{}, err
 	}
 
+	if err := r.cleanupGatewayLabelsOnDelete(ctx, aitenant); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	base := aitenant.DeepCopy()
 	controllerutil.RemoveFinalizer(aitenant, aitenantFinalizer)
 	if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
@@ -717,6 +1009,9 @@ func (r *AITenantReconciler) forceRemoveAITenantFinalizer(ctx context.Context, a
 	}
 	if err := r.deleteGatewayClaim(ctx, aitenant); err != nil {
 		log.Error(err, "best-effort deleteGatewayClaim failed during forced finalizer removal")
+	}
+	if err := r.cleanupGatewayLabelsOnDelete(ctx, aitenant); err != nil {
+		log.Error(err, "best-effort cleanupGatewayLabelsOnDelete failed during forced finalizer removal")
 	}
 
 	base := aitenant.DeepCopy()

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -3229,3 +3229,417 @@ func TestAITenantReconcile_DeletionTimeoutDisabledWhenZero(t *testing.T) {
 	g.Expect(res.RequeueAfter).To(BeNumerically(">", 0),
 		"should requeue for normal cleanup when timeout is disabled, not force-remove")
 }
+
+func gatewayWithMatchLabels(name string, matchLabels map[string]string) *gatewayapiv1.Gateway {
+	from := gatewayapiv1.NamespacesFromSelector
+	gw := existingAITenantGateway(name)
+	gw.Spec.Listeners = []gatewayapiv1.Listener{
+		{
+			Name: "https", Port: 443, Protocol: gatewayapiv1.HTTPSProtocolType,
+			AllowedRoutes: &gatewayapiv1.AllowedRoutes{
+				Namespaces: &gatewayapiv1.RouteNamespaces{
+					From: &from,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: matchLabels,
+					},
+				},
+			},
+		},
+	}
+	return gw
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsAppliesMatchLabels(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "redhat-ai-gateway-infra"}}
+	gw := gatewayWithMatchLabels("team-a", map[string]string{"maas-gateway-access": "true"})
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	g.Expect(r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)).To(Succeed())
+
+	var ns corev1.Namespace
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "redhat-ai-gateway-infra"}, &ns)).To(Succeed())
+	g.Expect(ns.Labels).To(HaveKeyWithValue("maas-gateway-access", "true"))
+
+	// Verify ownership annotation was set.
+	var ownership map[string][]string
+	g.Expect(json.Unmarshal([]byte(ns.Annotations[gatewayLabelsAnnotation]), &ownership)).To(Succeed())
+	g.Expect(ownership).To(HaveKeyWithValue("maas-gateway-access", []string{"team-a"}))
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsSkipsWhenNoSelector(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "redhat-ai-gateway-infra"}}
+	gw := existingAITenantGateway("team-a")
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	g.Expect(r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)).To(Succeed())
+
+	var ns corev1.Namespace
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "redhat-ai-gateway-infra"}, &ns)).To(Succeed())
+	g.Expect(ns.Labels).To(BeEmpty())
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsPreservesExistingLabels(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "redhat-ai-gateway-infra",
+		Labels: map[string]string{"app.kubernetes.io/managed-by": "maas-controller"},
+	}}
+	gw := gatewayWithMatchLabels("team-a", map[string]string{"maas-gateway-access": "true"})
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	g.Expect(r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)).To(Succeed())
+
+	var ns corev1.Namespace
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "redhat-ai-gateway-infra"}, &ns)).To(Succeed())
+	g.Expect(ns.Labels).To(HaveKeyWithValue("maas-gateway-access", "true"))
+	g.Expect(ns.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "maas-controller"))
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsSkipsPatchWhenAlreadyLabeled(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "redhat-ai-gateway-infra",
+		Labels:      map[string]string{"maas-gateway-access": "true"},
+		Annotations: map[string]string{gatewayLabelsAnnotation: `{"maas-gateway-access":["team-a"]}`},
+	}}
+	gw := gatewayWithMatchLabels("team-a", map[string]string{"maas-gateway-access": "true"})
+
+	patchCalled := false
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetName() == "redhat-ai-gateway-infra" {
+					patchCalled = true
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	g.Expect(r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)).To(Succeed())
+	g.Expect(patchCalled).To(BeFalse(), "should not patch when labels and ownership annotation are already correct")
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsRejectsConflictingValues(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "redhat-ai-gateway-infra"}}
+
+	from := gatewayapiv1.NamespacesFromSelector
+	gw := existingAITenantGateway("team-a")
+	gw.Spec.Listeners = []gatewayapiv1.Listener{
+		{
+			Name: "https", Port: 443, Protocol: gatewayapiv1.HTTPSProtocolType,
+			AllowedRoutes: &gatewayapiv1.AllowedRoutes{
+				Namespaces: &gatewayapiv1.RouteNamespaces{
+					From:     &from,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+				},
+			},
+		},
+		{
+			Name: "https-alt", Port: 8443, Protocol: gatewayapiv1.HTTPSProtocolType,
+			AllowedRoutes: &gatewayapiv1.AllowedRoutes{
+				Namespaces: &gatewayapiv1.RouteNamespaces{
+					From:     &from,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	err := r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("conflicting namespace selector values"))
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsRemovesStaleLabels(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	// The infra namespace has an old label "old-label=true" owned by gateway "team-a".
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "redhat-ai-gateway-infra",
+		Labels:      map[string]string{"old-label": "true", "unrelated": "keep"},
+		Annotations: map[string]string{gatewayLabelsAnnotation: `{"old-label":["team-a"]}`},
+	}}
+	// Gateway "team-a" now wants "new-label=true" only, not "old-label".
+	gw := gatewayWithMatchLabels("team-a", map[string]string{"new-label": "true"})
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	g.Expect(r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)).To(Succeed())
+
+	var ns corev1.Namespace
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "redhat-ai-gateway-infra"}, &ns)).To(Succeed())
+	g.Expect(ns.Labels).To(HaveKeyWithValue("new-label", "true"))
+	g.Expect(ns.Labels).NotTo(HaveKey("old-label"), "stale label must be removed")
+	g.Expect(ns.Labels).To(HaveKeyWithValue("unrelated", "keep"), "unrelated labels must be preserved")
+
+	var ownership map[string][]string
+	g.Expect(json.Unmarshal([]byte(ns.Annotations[gatewayLabelsAnnotation]), &ownership)).To(Succeed())
+	g.Expect(ownership).To(HaveKeyWithValue("new-label", []string{"team-a"}))
+	g.Expect(ownership).NotTo(HaveKey("old-label"))
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsRejectsCrossGatewayConflict(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	// The infra namespace has label "env=prod" owned by gateway "gateway-a".
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "redhat-ai-gateway-infra",
+		Labels:      map[string]string{"env": "prod"},
+		Annotations: map[string]string{gatewayLabelsAnnotation: `{"env":["gateway-a"]}`},
+	}}
+	// Gateway "gateway-b" wants "env=staging" — conflicts with gateway-a's value.
+	gw := gatewayWithMatchLabels("gateway-b", map[string]string{"env": "staging"})
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	err := r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("conflicting"))
+	g.Expect(err.Error()).To(ContainSubstring("gateway-a"))
+	g.Expect(err.Error()).To(ContainSubstring("gateway-b"))
+}
+
+func TestCleanupGatewayLabelsOnDelete(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	ctx := context.Background()
+
+	// The infra namespace has labels from two gateways.
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "redhat-ai-gateway-infra",
+		Labels: map[string]string{"team-a-label": "true", "team-b-label": "true", "unmanaged": "keep"},
+		Annotations: map[string]string{
+			gatewayLabelsAnnotation: `{"team-a-label":["team-a"],"team-b-label":["team-b"]}`,
+		},
+	}}
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a",
+			Namespace: tenantreconcile.DefaultAITenantNamespace,
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	g.Expect(r.cleanupGatewayLabelsOnDelete(ctx, aitenant)).To(Succeed())
+
+	var ns corev1.Namespace
+	g.Expect(cl.Get(ctx, client.ObjectKey{Name: "redhat-ai-gateway-infra"}, &ns)).To(Succeed())
+	g.Expect(ns.Labels).NotTo(HaveKey("team-a-label"), "labels owned by team-a must be removed")
+	g.Expect(ns.Labels).To(HaveKeyWithValue("team-b-label", "true"), "labels owned by team-b must be preserved")
+	g.Expect(ns.Labels).To(HaveKeyWithValue("unmanaged", "keep"), "unmanaged labels must be preserved")
+
+	var ownership map[string][]string
+	g.Expect(json.Unmarshal([]byte(ns.Annotations[gatewayLabelsAnnotation]), &ownership)).To(Succeed())
+	g.Expect(ownership).NotTo(HaveKey("team-a-label"))
+	g.Expect(ownership).To(HaveKeyWithValue("team-b-label", []string{"team-b"}))
+}
+
+func TestCleanupGatewayLabelsOnDeletePreservesSharedLabel(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	ctx := context.Background()
+
+	// Both gateways share the same label key with the same value.
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "redhat-ai-gateway-infra",
+		Labels: map[string]string{"maas-gateway-access": "true"},
+		Annotations: map[string]string{
+			gatewayLabelsAnnotation: `{"maas-gateway-access":["team-a","team-b"]}`,
+		},
+	}}
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a",
+			Namespace: tenantreconcile.DefaultAITenantNamespace,
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	g.Expect(r.cleanupGatewayLabelsOnDelete(ctx, aitenant)).To(Succeed())
+
+	var ns corev1.Namespace
+	g.Expect(cl.Get(ctx, client.ObjectKey{Name: "redhat-ai-gateway-infra"}, &ns)).To(Succeed())
+	g.Expect(ns.Labels).To(HaveKeyWithValue("maas-gateway-access", "true"),
+		"shared label must be preserved when another gateway still owns it")
+
+	var ownership map[string][]string
+	g.Expect(json.Unmarshal([]byte(ns.Annotations[gatewayLabelsAnnotation]), &ownership)).To(Succeed())
+	g.Expect(ownership).To(HaveKeyWithValue("maas-gateway-access", []string{"team-b"}))
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsRejectsCoOwnerValueChange(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	// Both gateways co-own "key" with value "true".
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "redhat-ai-gateway-infra",
+		Labels:      map[string]string{"key": "true"},
+		Annotations: map[string]string{gatewayLabelsAnnotation: `{"key":["gateway-a","gateway-b"]}`},
+	}}
+	// Gateway "gateway-b" now wants "key=false" — conflicts with co-owner gateway-a.
+	gw := gatewayWithMatchLabels("gateway-b", map[string]string{"key": "false"})
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	err := r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("conflicting"))
+	g.Expect(err.Error()).To(ContainSubstring("gateway-a"))
+	g.Expect(err.Error()).To(ContainSubstring("gateway-b"))
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsAllowsSharedOwnership(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	// Gateway "gateway-a" already owns "maas-gateway-access=true".
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "redhat-ai-gateway-infra",
+		Labels:      map[string]string{"maas-gateway-access": "true"},
+		Annotations: map[string]string{gatewayLabelsAnnotation: `{"maas-gateway-access":["gateway-a"]}`},
+	}}
+	// Gateway "gateway-b" also wants "maas-gateway-access=true" — same value, should succeed.
+	gw := gatewayWithMatchLabels("gateway-b", map[string]string{"maas-gateway-access": "true"})
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	g.Expect(r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)).To(Succeed())
+
+	var ns corev1.Namespace
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "redhat-ai-gateway-infra"}, &ns)).To(Succeed())
+	g.Expect(ns.Labels).To(HaveKeyWithValue("maas-gateway-access", "true"))
+
+	var ownership map[string][]string
+	g.Expect(json.Unmarshal([]byte(ns.Annotations[gatewayLabelsAnnotation]), &ownership)).To(Succeed())
+	g.Expect(ownership["maas-gateway-access"]).To(ConsistOf("gateway-a", "gateway-b"))
+}
+
+func TestEnsureInfraNamespaceGatewayLabelsRejectsUnownedConflict(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	// The infra namespace has a label set manually (no ownership entry).
+	infraNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "redhat-ai-gateway-infra",
+		Labels: map[string]string{"env": "prod"},
+	}}
+	// Gateway wants "env=staging" — conflicts with the unowned value.
+	gw := gatewayWithMatchLabels("gateway-a", map[string]string{"env": "staging"})
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(infraNs).Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "redhat-ai-gateway-infra",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	err := r.ensureInfraNamespaceGatewayLabels(context.Background(), gw)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("outside the controller"))
+	g.Expect(err.Error()).To(ContainSubstring("gateway-a"))
+
+	// Verify the label was not overwritten.
+	var ns corev1.Namespace
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "redhat-ai-gateway-infra"}, &ns)).To(Succeed())
+	g.Expect(ns.Labels).To(HaveKeyWithValue("env", "prod"))
+}

--- a/scripts/create-ai-tenant.sh
+++ b/scripts/create-ai-tenant.sh
@@ -28,15 +28,14 @@
 #   Per-tenant Gateways receive HTTPRoutes from the infrastructure namespace (where
 #   maas-api is deployed) and from any model namespaces (where LLMInferenceServices
 #   run). Since these namespaces vary per cluster, the recommended approach is a
-#   per-gateway label selector. After running this script, label each namespace that
-#   needs to attach HTTPRoutes:
+#   per-gateway label selector. The controller automatically labels the
+#   infrastructure namespace. After running this script, label any model
+#   namespaces that need to attach HTTPRoutes:
 #
 #   NAMESPACE_SELECTOR_LABELS="maas.opendatahub.io/gateway-access-myteam=true" \
 #     ./scripts/create-ai-tenant.sh myteam
 #
-#   # Then label the infra namespace and any model namespaces:
-#   oc label namespace odh-ai-gateway-infra \
-#     maas.opendatahub.io/gateway-access-myteam=true --overwrite
+#   # Label model namespaces (infra namespace is labeled automatically):
 #   oc label namespace llm \
 #     maas.opendatahub.io/gateway-access-myteam=true --overwrite
 #


### PR DESCRIPTION


Cherry-pick https://github.com/opendatahub-io/models-as-a-service/pull/1370

When a gateway's listeners use allowedRoutes with namespace selectors (matchLabels), the AITenant reconciler now reads those labels and applies them to the shared infrastructure namespace. This ensures hardened gateways accept per-tenant maas-api HTTPRoutes without manual labeling.

[RHOAIENG-83294](https://redhat.atlassian.net/browse/RHOAIENG-83294)

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Please describe in detail how you tested your changes. --> <!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests
- manual on cluster: -- create gateway with
```
  {
      "namespaces": {
          "from": "Selector",
          "selector": {
              "matchLabels": {
                  "maas-gateway-access": "true"
              }
          }
      }
  }
```

-- observe apikey creation fails with 500 response -- rollout maas-controller with this fix
-- observe apikey creation succeeds.

-- Create new tenant:
--- NAMESPACE_SELECTOR_LABELS="maas-gateway-access-redteam=true" ./scripts/create-ai-tenant.sh redteam
--- observe no 500 response on apikey creation

--- observe infra namespace has both labels
```
$ oc get namespace odh-ai-gateway-infra --show-labels
NAME                   STATUS   AGE    LABELS
odh-ai-gateway-infra   Active   156m   kubernetes.io/metadata.name=odh-ai-gateway-infra,maas-gateway-access-redteam=true,maas-gateway-access=true,opendatahub.io/generated-namespace=true,pod-security.kubernetes.io/audit-version=latest,pod-security.kubernetes.io/audit=restricted,pod-security.kubernetes.io/warn-version=latest,pod-security.kubernetes.io/warn=restricted
```

EDIT:  after reconciliation added:

```
$ oc get ns odh-ai-gateway-infra -o jsonpath='Labels:      {.metadata.labels}{"\n"}Ownership:   {.metadata.annotations.maas\.opendatahub\.io/gateway-selector-labels}{"\n"}'
Labels:      {"kubernetes.io/metadata.name":"odh-ai-gateway-infra","maas-gateway-access":"true","opendatahub.io/generated-namespace":"true","pod-security.kubernetes.io/audit":"restricted","pod-security.kubernetes.io/audit-version":"latest","pod-security.kubernetes.io/warn":"restricted","pod-security.kubernetes.io/warn-version":"latest"}
Ownership:   {"maas-gateway-access":["maas-default-gateway"]}
$
$
$ NAMESPACE_SELECTOR_LABELS="maas-gateway-access=true" ./scripts/create-ai-tenant.sh redteam > /dev/null
$
$ oc get ns odh-ai-gateway-infra -o jsonpath='Labels:      {.metadata.labels}{"\n"}Ownership:   {.metadata.annotations.maas\.opendatahub\.io/gateway-selector-labels}{"\n"}'
Labels:      {"kubernetes.io/metadata.name":"odh-ai-gateway-infra","maas-gateway-access":"true","opendatahub.io/generated-namespace":"true","pod-security.kubernetes.io/audit":"restricted","pod-security.kubernetes.io/audit-version":"latest","pod-security.kubernetes.io/warn":"restricted","pod-security.kubernetes.io/warn-version":"latest"}
Ownership:   {"maas-gateway-access":["maas-default-gateway","redteam"]}
$
$ NAMESPACE_SELECTOR_LABELS="env=staging" ./scripts/create-ai-tenant.sh staging > /dev/null
$ oc get ns odh-ai-gateway-infra -o jsonpath='Labels:      {.metadata.labels}{"\n"}Ownership:   {.metadata.annotations.maas\.opendatahub\.io/gateway-selector-labels}{"\n"}'
Labels:      {"env":"staging","kubernetes.io/metadata.name":"odh-ai-gateway-infra","maas-gateway-access":"true","opendatahub.io/generated-namespace":"true","pod-security.kubernetes.io/audit":"restricted","pod-security.kubernetes.io/audit-version":"latest","pod-security.kubernetes.io/warn":"restricted","pod-security.kubernetes.io/warn-version":"latest"}
Ownership:   {"env":["staging"],"maas-gateway-access":["maas-default-gateway","redteam"]}
$ NAMESPACE_SELECTOR_LABELS="env=prod" ./scripts/create-ai-tenant.sh prod > /dev/null
$ oc get ns odh-ai-gateway-infra -o jsonpath='Labels:      {.metadata.labels}{"\n"}Ownership:   {.metadata.annotations.maas\.opendatahub\.io/gateway-selector-labels}{"\n"}'
Labels:      {"env":"staging","kubernetes.io/metadata.name":"odh-ai-gateway-infra","maas-gateway-access":"true","opendatahub.io/generated-namespace":"true","pod-security.kubernetes.io/audit":"restricted","pod-security.kubernetes.io/audit-version":"latest","pod-security.kubernetes.io/warn":"restricted","pod-security.kubernetes.io/warn-version":"latest"}
Ownership:   {"env":["staging"],"maas-gateway-access":["maas-default-gateway","redteam"]}
$ oc get aitenant prod -n ai-tenants -o yaml
apiVersion: maas.opendatahub.io/v1alpha1
kind: AITenant
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"maas.opendatahub.io/v1alpha1","kind":"AITenant","metadata":{"annotations":{},"name":"prod","namespace":"ai-tenants"}}
  creationTimestamp: "2026-08-14T14:31:42Z"
  finalizers:
  - maas.opendatahub.io/aitenant-cleanup
  generation: 1
  name: prod
  namespace: ai-tenants
  resourceVersion: "59528"
  uid: 656a26e7-b897-4b08-b7e2-f2a4cccd023e
status:
  conditions:
  - lastTransitionTime: "2026-08-14T14:31:43Z"
    message: 'conflicting gateway label "env" on infra namespace odh-ai-gateway-infra:
      owned by gateway "staging" (value "staging") but gateway "prod" wants "prod"'
    observedGeneration: 1
    reason: InfraNamespaceLabelFailed
    status: "False"
    type: Ready
  gatewayRef:
    name: prod
    namespace: openshift-ingress
  phase: Failed
  tenantNamespace: ai-tenant-prod
$ oc delete aitenant redteam -n ai-tenants
aitenant.maas.opendatahub.io "redteam" deleted from ai-tenants namespace
$ oc get ns odh-ai-gateway-infra -o jsonpath='Labels:      {.metadata.labels}{"\n"}Ownership:   {.metadata.annotations.maas\.opendatahub\.io/gateway-selector-labels}{"\n"}'
Labels:      {"env":"staging","kubernetes.io/metadata.name":"odh-ai-gateway-infra","maas-gateway-access":"true","opendatahub.io/generated-namespace":"true","pod-security.kubernetes.io/audit":"restricted","pod-security.kubernetes.io/audit-version":"latest","pod-security.kubernetes.io/warn":"restricted","pod-security.kubernetes.io/warn-version":"latest"}
Ownership:   {"env":["staging"],"maas-gateway-access":["maas-default-gateway"]}

```

<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-83294]:
https://redhat.atlassian.net/browse/RHOAIENG-83294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Gateway listener label selectors are automatically synchronized to the configured infrastructure namespace.
- Existing labels are preserved, stale labels are removed, and shared labels remain supported.
- Gateway changes automatically trigger affected tenant updates.
- Conflicting label values are detected and rejected.

- Improved cleanup of labels when Gateways or tenants are deleted.
- Improved reconciliation error reporting for namespace label failures.

- Updated setup guides and examples to clarify that only model namespaces require manual labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------