### PR TITLE
fix(RHOAIENG-84699): use CEL in operator for deny-client-identity-headers

### DIFF
--- a/deployment/base/maas-api/policies/auth-policy.yaml
+++ b/deployment/base/maas-api/policies/auth-policy.yaml
@@ -55,8 +55,9 @@ spec:
         priority: 0
         patternMatching:
           patterns:
-            - predicate: '!has(request.headers["x-maas-username"])'
-            - predicate: '!has(request.headers["x-maas-group"])'
+            # CEL has() only works on message fields; use `in` for map keys (Authorino).
+            - predicate: '!("x-maas-username" in request.headers)'
+            - predicate: '!("x-maas-group" in request.headers)'
       # Check API key is valid (only for API key auth)
       api-key-valid:
         when:


### PR DESCRIPTION
Resovles: https://redhat.atlassian.net/browse/RHOAIENG-84699

## Summary
- The backport in 6858baa7 used `has(request.headers["x-maas-username"])` which is invalid in Authorino v1.4.2 — CEL `has()` only accepts field selection, not map subscript
- Both AuthConfigs go `Ready: false` / `Invalid`, causing every gateway request to return 500
- All 8 MaaS Billing tests fail at the `maas_api_gateway_reachable` fixture (300s timeout, `Last exception: N/A`)
- Fix: change to `"x-maas-username" in request.headers` (standard CEL map key existence), matching `main` and `rhoai-3.5`

## Verified on cluster
```
oc get authconfig -n kuadrant-system
NAME                                                               READY   HOSTS
106ee193ed5da8894b4618edaea1ca7b22591fcbb888aacab8d307a22237ad8a   false   0/1
f3bfde46dfad0f0a398e69354496cd3ff518317fe7a8adb3a202758d6505437b   false   0/1
```
AuthConfig error:
```
ERROR: <input>:1:21: invalid argument to has() macro
 | !has(request.headers["x-maas-username"])
 | ....................^
```
`curl http://maas.apps.<cluster>/maas-api/v1/models` → HTTP 500




## Test plan
- [ ] Verify AuthConfigs become `Ready: true` after redeploying with this fix
- [ ] `curl http://maas.<cluster>/maas-api/v1/models` returns 401 (auth required) instead of 500
- [ ] Re-run MaaS Billing test suite — all 8 tests should pass setup fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)