### PR TITLE
fix: honour E2E_MODEL_PATH in model_base_url to avoid BBR gateway-root 404

### DIFF
--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -180,13 +180,21 @@ def model_id(model_catalog: dict):
 
 @pytest.fixture(scope="session")
 def model_base_url(model_catalog: dict, model_id: str, gateway_url: str) -> str:
+    # E2E_MODEL_PATH provides an explicit path override for clusters that use per-model
+    # path-based routing (e.g. /llm/{model-name}) rather than BBR gateway-root routing.
+    # Without this, the catalog url field (gateway root on BBR clusters) produces a path
+    # of "" which resolves to gateway_root — a path with no HTTPRoute → 404.
+    path_override = os.environ.get("E2E_MODEL_PATH")
+    if path_override:
+        return f"{gateway_url}{path_override}".rstrip("/")
     items = (model_catalog.get("data") or model_catalog.get("models") or [])
     match = next((m for m in items if m.get("id") == model_id), None)
     if match:
         url = match.get("url")
         if url:
             path = urlparse(url).path
-            return f"{gateway_url}{path}".rstrip("/")
+            if path and path != "/":
+                return f"{gateway_url}{path}".rstrip("/")
     return f"{gateway_url}/llm/{model_id}".rstrip("/")
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

- On BBR-configured clusters, `maas-api` returns the MaaS gateway base URL (e.g. `https://maas.apps.../`) as the `url` field in `GET /v1/models`, not a model-specific path. `conftest.py` built `model_base_url` from that URL's path component — which is empty — so every inference test hit `gateway_root/v1/completions`, a path with no HTTPRoute on `maas-default-gateway` → 404.
- This caused 20+ test failures in the Shepard nightly (`test_api_keys`, `test_subscription`, `test_models_endpoint`, `test_x_api_key_auth`, and others) across both rhoai-3.5 and rhoai-3.6-ea.1 runs.

## Changes

**`test/e2e/tests/conftest.py` — `model_base_url` fixture:**

1. **Honour `E2E_MODEL_PATH`** — already exported by `Jenkinsfile.maas-tests` (Shepard) as `/llm/{model-ref-name}`. When set, use it directly as the model path rather than deriving from the catalog response. Inference tests now hit `gateway_root/llm/{model}/v1/completions`, which the maas-controller HTTPRoute handles correctly.
2. **Guard the catalog-url path branch** — skip it when the path is empty or `"/"` (i.e. a BBR gateway-root URL), falling through to the existing `/llm/{model_id}` fallback instead of silently producing a wrong base URL.

## Root cause investigation

Diagnosed from Shepard build [#278](https://jenkins-csb-wxai-main.dno.corp.redhat.com/job/3.5/job/maas-tests/278/) console log and live cluster inspection:

- `GET /maas-api/v1/models` → `"url": "https://maas.apps.rhoai-test-pool-t5gtx.aws.rh-ods.com"` (gateway root, intentional BBR behaviour in maas-api)
- `conftest.py` extracted path `""` → `model_completions_url = "https://maas.apps.rhoai-test-pool-t5gtx.aws.rh-ods.com/v1/completions"`
- `oc get httproute --all-namespaces` confirmed no HTTPRoute on `maas-default-gateway` handles `/v1/completions` without ExternalModel/IPP deployed → 404

## Risk analysis

**Risk rating: 1**

**Why:** Test-only change (`test/e2e/tests/conftest.py`). No production code, no CRD, no Kustomize. The `E2E_MODEL_PATH` override is already set in `Jenkinsfile.maas-tests`; adding the check to conftest is purely additive. The `path != "/"` guard is a defensive improvement to the existing fallback logic.

## Test plan

- [ ] Shepard nightly run on rhoai-3.5 / rhoai-3.6-ea.1 after merge — expect `test_api_keys::TestAPIKeyModelInference` and related inference tests to pass (currently failing with 404)
- [ ] Prow smoke unaffected — `E2E_MODEL_PATH` not set in prow, falls through to existing logic unchanged