### PR TITLE
feat: add request histograms and rejection counters to maas-api (#1415)

### DIFF
--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -259,8 +259,8 @@ func registerHandlers(
 	}
 
 	tokenHandler := token.NewHandler(log, cfg.TenantName)
-	modelsHandler := handlers.NewModelsHandler(log, modelManager, subscriptionSelector, cluster.MaaSModelRefLister)
-	subscriptionHandler := subscription.NewHandler(log, subscriptionSelector)
+	modelsHandler := handlers.NewModelsHandler(log, modelManager, subscriptionSelector, cluster.MaaSModelRefLister, metricsRecorder)
+	subscriptionHandler := subscription.NewHandler(log, subscriptionSelector, metricsRecorder)
 
 	apiKeyService := api_keys.NewServiceWithLogger(store, cfg, subscriptionSelector, log)
 	apiKeyService.StartDebounceCleanup(ctx)

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -54,6 +54,7 @@ type Handler struct {
 type MetricsRecorder interface {
 	RecordKeyValidation(tenant, result string)
 	RecordTokenMint(tenant, result string)
+	RecordRejection(reason string)
 }
 
 func (h *Handler) GetAPIKeyConfig(c *gin.Context) {
@@ -398,6 +399,10 @@ func (h *Handler) ValidateAPIKeyHandler(c *gin.Context) {
 	}
 
 	if !result.Valid {
+		// Record rejection for invalid API key
+		if h.metrics != nil {
+			h.metrics.RecordRejection(constant.RejectionUnauthorized)
+		}
 		// Return 200 with validation result for Authorino
 		// Per design doc section 7.7: invalid keys should return 200 with valid:false
 		c.JSON(http.StatusOK, result)

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -126,6 +126,7 @@ type metricsCall struct {
 type spyMetricsRecorder struct {
 	keyValidations []metricsCall
 	tokenMints     []metricsCall
+	rejections     []string
 }
 
 func (s *spyMetricsRecorder) RecordKeyValidation(tenant, result string) {
@@ -134,6 +135,10 @@ func (s *spyMetricsRecorder) RecordKeyValidation(tenant, result string) {
 
 func (s *spyMetricsRecorder) RecordTokenMint(tenant, result string) {
 	s.tokenMints = append(s.tokenMints, metricsCall{tenant, result})
+}
+
+func (s *spyMetricsRecorder) RecordRejection(reason string) {
+	s.rejections = append(s.rejections, reason)
 }
 
 // TestCreateAPIKey_TokenMintMetrics verifies that the token mint counter records
@@ -206,6 +211,27 @@ func TestValidateAPIKey_RecordsValidationMetric(t *testing.T) {
 	require.Len(t, spy.keyValidations, 1)
 	assert.Equal(t, "redteam", spy.keyValidations[0].tenant)
 	assert.Equal(t, "valid", spy.keyValidations[0].result)
+}
+
+func TestValidateAPIKey_RecordsUnauthorizedRejection(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewMockStore()
+	cfg := &config.Config{}
+	service := NewServiceWithLogger(store, cfg, fixedSubSelector{}, logger.Development())
+	spy := &spyMetricsRecorder{}
+	handler := NewHandler(logger.Development(), service, newMockAdminChecker(), spy)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/internal/v1/api-keys/validate", nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Body = io.NopCloser(strings.NewReader(`{"key": "invalid-key"}`))
+
+	handler.ValidateAPIKeyHandler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, spy.rejections, 1)
+	assert.Equal(t, "unauthorized", spy.rejections[0])
 }
 
 func TestIsAuthorizedForKey(t *testing.T) {

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -37,4 +37,10 @@ const (
 	MaxLabelsEntries    = 50
 	MaxLabelKeyLength   = 128
 	MaxLabelValueLength = 1024
+
+	// Rejection reason constants for metrics.
+	RejectionRateLimited   = "rate-limited"
+	RejectionUnauthorized  = "unauthorized"
+	RejectionNoCapacity    = "no-capacity"
+	RejectionQuotaExceeded = "quota-exceeded"
 )

--- a/maas-api/internal/handlers/models.go
+++ b/maas-api/internal/handlers/models.go
@@ -10,11 +10,17 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v2/packages/pagination"
 
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/models"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/token"
 )
+
+// MetricsRecorder is the subset of metrics.MetricsRecorder used by this handler.
+type MetricsRecorder interface {
+	RecordRejection(reason string)
+}
 
 // ModelsHandler handles model-related endpoints.
 type ModelsHandler struct {
@@ -22,6 +28,7 @@ type ModelsHandler struct {
 	subscriptionSelector *subscription.Selector
 	logger               *logger.Logger
 	maasModelRefLister   models.MaaSModelRefLister
+	metrics              MetricsRecorder
 }
 
 // NewModelsHandler creates a new models handler.
@@ -31,6 +38,7 @@ func NewModelsHandler(
 	modelMgr *models.Manager,
 	subscriptionSelector *subscription.Selector,
 	maasModelRefLister models.MaaSModelRefLister,
+	metrics MetricsRecorder,
 ) *ModelsHandler {
 	if log == nil {
 		log = logger.Production()
@@ -40,6 +48,7 @@ func NewModelsHandler(
 		subscriptionSelector: subscriptionSelector,
 		logger:               log,
 		maasModelRefLister:   maasModelRefLister,
+		metrics:              metrics,
 	}
 }
 
@@ -169,6 +178,9 @@ func (h *ModelsHandler) extractAndValidateAuth(c *gin.Context) (string, string, 
 	authHeader := strings.TrimSpace(c.GetHeader("Authorization"))
 	if authHeader == "" {
 		h.logger.Debug("Authorization header missing") // SAFE: Logging that header is missing, not the value itself
+		if h.metrics != nil {
+			h.metrics.RecordRejection(constant.RejectionUnauthorized)
+		}
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"error": gin.H{
 				"message": "Authorization required",

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -375,7 +375,7 @@ func TestListingModels(t *testing.T) { //nolint:maintidx // table-driven test wi
 	// Create a mock subscription selector that auto-selects for single subscription users
 	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{}, nil, nil)
 
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister, nil)
 
 	// Create token handler to extract user info middleware
 	tokenHandler := token.NewHandler(testLogger, fixtures.TestTenant)
@@ -507,7 +507,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 	}
 	subscriptionSelector := subscription.NewSelector(testLogger, multiSubLister, nil, nil)
 
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister, nil)
 	tokenHandler := token.NewHandler(testLogger, fixtures.TestTenant)
 
 	v1 := router.Group("/v1")
@@ -729,7 +729,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister, nil)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
 	router, _ := fixtures.SetupTestServer(t, config)
@@ -782,7 +782,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		}
 
 		subscriptionSelector := subscription.NewSelector(testLogger, emptySubscriptionLister, nil, nil)
-		emptyHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
+		emptyHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister, nil)
 
 		config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
 		router2, _ := fixtures.SetupTestServer(t, config)
@@ -918,7 +918,7 @@ func TestListModels_DeduplicationBySubscription(t *testing.T) {
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister, nil)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
 	router, _ := fixtures.SetupTestServer(t, config)
@@ -1036,7 +1036,7 @@ func TestListModels_DifferentModelRefsWithSameModelID(t *testing.T) {
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister, nil)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
 	router, _ := fixtures.SetupTestServer(t, config)
@@ -1144,7 +1144,7 @@ func TestListModels_DifferentModelRefsWithSameURLAndModelID(t *testing.T) {
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister, nil)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
 	router, _ := fixtures.SetupTestServer(t, config)
@@ -1251,7 +1251,7 @@ func TestListModels_DifferentModelRefsWithSameModelIDAndDifferentSubscriptions(t
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister, nil)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
 	router, _ := fixtures.SetupTestServer(t, config)
@@ -1345,7 +1345,7 @@ func TestListModels_ExternalModelUsesModelRefName(t *testing.T) {
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{}, lister, nil)
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister, nil)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
 	router, _ := fixtures.SetupTestServer(t, config)
@@ -1400,7 +1400,8 @@ func TestListModels_NoAuthContext(t *testing.T) {
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{}, nil, nil)
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
+	spy := &spyModelsMetrics{}
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister, spy)
 
 	cfg := fixtures.TestServerConfig{Objects: []runtime.Object{}}
 	router, _ := fixtures.SetupTestServer(t, cfg)
@@ -1463,6 +1464,7 @@ func TestListModels_NoAuthContext(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusUnauthorized, w.Code, "Should return 401 when Authorization missing but identity present")
+		require.Equal(t, []string{constant.RejectionUnauthorized}, spy.rejections)
 	})
 
 	t.Run("returns normal response when all auth headers present", func(t *testing.T) {
@@ -1519,4 +1521,12 @@ func TestListModels_StrictAuthOnOtherEndpoints(t *testing.T) {
 		assert.Equal(t, "AUTH_FAILURE", body["exceptionCode"],
 			"Should return AUTH_FAILURE for missing headers on strict endpoints")
 	})
+}
+
+type spyModelsMetrics struct {
+	rejections []string
+}
+
+func (s *spyModelsMetrics) RecordRejection(reason string) {
+	s.rejections = append(s.rejections, reason)
 }

--- a/maas-api/internal/metrics/middleware.go
+++ b/maas-api/internal/metrics/middleware.go
@@ -27,5 +27,6 @@ func NewMiddleware(recorder MetricsRecorder, defaultTenant string) gin.HandlerFu
 
 		status := strconv.Itoa(c.Writer.Status())
 		recorder.RecordRequestDuration(method, route, status, defaultTenant, duration)
+		recorder.RecordRequest(duration)
 	}
 }

--- a/maas-api/internal/metrics/middleware_tenant_test.go
+++ b/maas-api/internal/metrics/middleware_tenant_test.go
@@ -42,6 +42,10 @@ func TestMiddleware_UsesConfiguredTenantRegardlessOfUserContext(t *testing.T) {
 	val := gatherMetricValue(t, reg, "maas_api_http_requests_total",
 		map[string]string{"method": "GET", "route": "/v1/models", "status": "200", "tenant_name": "models-as-a-service"})
 	assert.InDelta(t, float64(1), val, 0)
+
+	// Verify new maas_requests_total metric is also populated
+	maasVal := gatherMetricValue(t, reg, "maas_requests_total", nil)
+	assert.InDelta(t, float64(1), maasVal, 0)
 }
 
 // TestMiddleware_DefaultTenantWhenNoUserContext verifies that requests without
@@ -67,4 +71,8 @@ func TestMiddleware_DefaultTenantWhenNoUserContext(t *testing.T) {
 	val := gatherMetricValue(t, reg, "maas_api_http_requests_total",
 		map[string]string{"method": "GET", "route": "/health", "status": "200", "tenant_name": "models-as-a-service"})
 	assert.InDelta(t, float64(1), val, 0)
+
+	// Verify new maas_requests_total metric is also populated
+	maasVal := gatherMetricValue(t, reg, "maas_requests_total", nil)
+	assert.InDelta(t, float64(1), maasVal, 0)
 }

--- a/maas-api/internal/metrics/prometheus.go
+++ b/maas-api/internal/metrics/prometheus.go
@@ -5,14 +5,26 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 )
 
 type PrometheusRecorder struct {
-	requestsTotal   *prometheus.CounterVec
-	requestDuration *prometheus.HistogramVec
-	inFlight        *prometheus.GaugeVec
-	keyValidation   *prometheus.CounterVec
-	tokenMint       *prometheus.CounterVec
+	requestsTotal         *prometheus.CounterVec
+	requestDuration       *prometheus.HistogramVec
+	inFlight              *prometheus.GaugeVec
+	keyValidation         *prometheus.CounterVec
+	tokenMint             *prometheus.CounterVec
+	maasRequestsTotal     prometheus.Counter
+	maasRequestDuration   prometheus.Histogram
+	maasRequestRejections *prometheus.CounterVec
+}
+
+var allowedRejectionReasons = map[string]struct{}{
+	constant.RejectionRateLimited:   {},
+	constant.RejectionUnauthorized:  {},
+	constant.RejectionNoCapacity:    {},
+	constant.RejectionQuotaExceeded: {},
 }
 
 func NewPrometheusRecorder(reg prometheus.Registerer) (*PrometheusRecorder, error) {
@@ -45,18 +57,44 @@ func NewPrometheusRecorder(reg prometheus.Registerer) (*PrometheusRecorder, erro
 		Help: "Total number of API key mints by tenant and result.",
 	}, []string{"tenant_name", "result"})
 
-	for _, c := range []prometheus.Collector{requestsTotal, requestDuration, inFlight, keyValidation, tokenMint} {
+	// Unlabeled so a representative scrape stays under the 20-series ceiling.
+	// Histogram (not HistogramVec) materializes every bucket at Register.
+	maasRequestsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "maas_requests_total",
+		Help: "Total number of HTTP requests served.",
+	})
+
+	maasRequestDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "maas_request_duration_seconds",
+		Help:    "HTTP request latency in seconds.",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	maasRequestRejections := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "maas_request_rejections_total",
+		Help: "Total number of routing rejections by reason.",
+	}, []string{"reason"})
+
+	for _, c := range []prometheus.Collector{requestsTotal, requestDuration, inFlight, keyValidation, tokenMint, maasRequestsTotal, maasRequestDuration, maasRequestRejections} {
 		if err := reg.Register(c); err != nil {
 			return nil, err
 		}
 	}
 
+	maasRequestRejections.WithLabelValues(constant.RejectionRateLimited)
+	maasRequestRejections.WithLabelValues(constant.RejectionUnauthorized)
+	maasRequestRejections.WithLabelValues(constant.RejectionNoCapacity)
+	maasRequestRejections.WithLabelValues(constant.RejectionQuotaExceeded)
+
 	return &PrometheusRecorder{
-		requestsTotal:   requestsTotal,
-		requestDuration: requestDuration,
-		inFlight:        inFlight,
-		keyValidation:   keyValidation,
-		tokenMint:       tokenMint,
+		requestsTotal:         requestsTotal,
+		requestDuration:       requestDuration,
+		inFlight:              inFlight,
+		keyValidation:         keyValidation,
+		tokenMint:             tokenMint,
+		maasRequestsTotal:     maasRequestsTotal,
+		maasRequestDuration:   maasRequestDuration,
+		maasRequestRejections: maasRequestRejections,
 	}, nil
 }
 
@@ -79,4 +117,16 @@ func (r *PrometheusRecorder) IncrementInFlight(method string) {
 
 func (r *PrometheusRecorder) DecrementInFlight(method string) {
 	r.inFlight.WithLabelValues(method).Dec()
+}
+
+func (r *PrometheusRecorder) RecordRequest(duration time.Duration) {
+	r.maasRequestsTotal.Inc()
+	r.maasRequestDuration.Observe(duration.Seconds())
+}
+
+func (r *PrometheusRecorder) RecordRejection(reason string) {
+	if _, ok := allowedRejectionReasons[reason]; !ok {
+		return
+	}
+	r.maasRequestRejections.WithLabelValues(reason).Inc()
 }

--- a/maas-api/internal/metrics/prometheus_test.go
+++ b/maas-api/internal/metrics/prometheus_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -173,4 +174,162 @@ func TestDurationHistogramObserved(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "histogram metric not found in registry")
+}
+
+func TestRecordRequest(t *testing.T) {
+	r, reg := newTestRecorder(t)
+
+	r.RecordRequest(150 * time.Millisecond)
+	r.RecordRequest(250 * time.Millisecond)
+	r.RecordRequest(50 * time.Millisecond)
+
+	assert.InDelta(t, float64(3), gatherMetricValue(t, reg, "maas_requests_total", nil), 0)
+}
+
+func TestRecordRequestHistogram(t *testing.T) {
+	r, reg := newTestRecorder(t)
+
+	r.RecordRequest(150 * time.Millisecond)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() == "maas_request_duration_seconds" {
+			found = true
+			require.Len(t, f.GetMetric(), 1)
+			assert.Equal(t, uint64(1), f.GetMetric()[0].GetHistogram().GetSampleCount())
+			assert.NotEmpty(t, f.GetMetric()[0].GetHistogram().GetBucket())
+		}
+	}
+	assert.True(t, found, "maas_request_duration_seconds histogram not found")
+}
+
+func TestRequestHistogramBucketsRegisteredAtStartup(t *testing.T) {
+	_, reg := newTestRecorder(t)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() != "maas_request_duration_seconds" {
+			continue
+		}
+		found = true
+		require.Len(t, f.GetMetric(), 1)
+		assert.Equal(t, uint64(0), f.GetMetric()[0].GetHistogram().GetSampleCount())
+		assert.Len(t, f.GetMetric()[0].GetHistogram().GetBucket(), len(prometheus.DefBuckets))
+	}
+	assert.True(t, found, "histogram buckets must exist at registration before any Observe")
+}
+
+func TestRecordRejection(t *testing.T) {
+	r, reg := newTestRecorder(t)
+
+	r.RecordRejection("unauthorized")
+	r.RecordRejection("unauthorized")
+	r.RecordRejection("rate-limited")
+	r.RecordRejection("no-capacity")
+	r.RecordRejection("quota-exceeded")
+
+	assert.InDelta(t, float64(2), gatherMetricValue(t, reg, "maas_request_rejections_total",
+		map[string]string{"reason": "unauthorized"}), 0)
+	assert.InDelta(t, float64(1), gatherMetricValue(t, reg, "maas_request_rejections_total",
+		map[string]string{"reason": "rate-limited"}), 0)
+	assert.InDelta(t, float64(1), gatherMetricValue(t, reg, "maas_request_rejections_total",
+		map[string]string{"reason": "no-capacity"}), 0)
+	assert.InDelta(t, float64(1), gatherMetricValue(t, reg, "maas_request_rejections_total",
+		map[string]string{"reason": "quota-exceeded"}), 0)
+}
+
+func TestRecordRejectionIgnoresUnknownReason(t *testing.T) {
+	r, reg := newTestRecorder(t)
+
+	r.RecordRejection("not-a-ticket-reason")
+
+	assert.InDelta(t, float64(0), gatherMetricValue(t, reg, "maas_request_rejections_total",
+		map[string]string{"reason": "rate-limited"}), 0)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != "maas_request_rejections_total" {
+			continue
+		}
+		assert.Len(t, f.GetMetric(), 4, "unknown reasons must not create extra series")
+	}
+}
+
+func TestRejectionLabelsPreInitialized(t *testing.T) {
+	_, reg := newTestRecorder(t)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	var rejectionMetric *struct{}
+	reasons := make(map[string]bool)
+
+	for _, f := range families {
+		if f.GetName() == "maas_request_rejections_total" {
+			rejectionMetric = &struct{}{}
+			for _, m := range f.GetMetric() {
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == "reason" {
+						reasons[lp.GetValue()] = true
+					}
+				}
+			}
+		}
+	}
+
+	require.NotNil(t, rejectionMetric, "maas_request_rejections_total not found")
+	assert.True(t, reasons["rate-limited"], "rate-limited label not pre-initialized")
+	assert.True(t, reasons["unauthorized"], "unauthorized label not pre-initialized")
+	assert.True(t, reasons["no-capacity"], "no-capacity label not pre-initialized")
+	assert.True(t, reasons["quota-exceeded"], "quota-exceeded label not pre-initialized")
+}
+
+func TestNewMetricsStayUnderCardinalityCeiling(t *testing.T) {
+	r, reg := newTestRecorder(t)
+	r.RecordRequest(10 * time.Millisecond)
+	r.RecordRejection("unauthorized")
+	r.RecordRejection("rate-limited")
+	r.RecordRejection("no-capacity")
+	r.RecordRejection("quota-exceeded")
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	const ceiling = 20
+	newMetrics := map[string]int{
+		"maas_requests_total":           0,
+		"maas_request_duration_seconds": 0,
+		"maas_request_rejections_total": 0,
+	}
+	for _, f := range families {
+		name := f.GetName()
+		if _, ok := newMetrics[name]; !ok {
+			continue
+		}
+		newMetrics[name] = timeSeriesCount(f)
+	}
+	for name, count := range newMetrics {
+		assert.Positive(t, count, "%s missing from registry", name)
+		assert.LessOrEqual(t, count, ceiling, "%s produced %d time series (ceiling %d)", name, count, ceiling)
+	}
+}
+
+func timeSeriesCount(f *dto.MetricFamily) int {
+	total := 0
+	for _, m := range f.GetMetric() {
+		if f.GetType() == dto.MetricType_HISTOGRAM {
+			// Finite buckets from the proto, plus +Inf, _sum, and _count.
+			total += len(m.GetHistogram().GetBucket()) + 3
+			continue
+		}
+		total++
+	}
+	return total
 }

--- a/maas-api/internal/metrics/recorder.go
+++ b/maas-api/internal/metrics/recorder.go
@@ -8,4 +8,6 @@ type MetricsRecorder interface {
 	RecordTokenMint(tenant, result string)
 	IncrementInFlight(method string)
 	DecrementInFlight(method string)
+	RecordRequest(duration time.Duration)
+	RecordRejection(reason string)
 }

--- a/maas-api/internal/metrics/recorder_test.go
+++ b/maas-api/internal/metrics/recorder_test.go
@@ -15,6 +15,8 @@ import (
 
 type mockRecorder struct {
 	durations   []recordedDuration
+	requests    []recordedRequest
+	rejections  []string
 	inFlightInc []string
 	inFlightDec []string
 }
@@ -24,8 +26,20 @@ type recordedDuration struct {
 	duration                      time.Duration
 }
 
+type recordedRequest struct {
+	duration time.Duration
+}
+
 func (m *mockRecorder) RecordRequestDuration(method, route, status, tenant string, d time.Duration) {
 	m.durations = append(m.durations, recordedDuration{method, route, status, tenant, d})
+}
+
+func (m *mockRecorder) RecordRequest(d time.Duration) {
+	m.requests = append(m.requests, recordedRequest{d})
+}
+
+func (m *mockRecorder) RecordRejection(reason string) {
+	m.rejections = append(m.rejections, reason)
 }
 
 func (m *mockRecorder) IncrementInFlight(method string) {
@@ -102,4 +116,17 @@ func TestMiddlewareUnmatchedRoute(t *testing.T) {
 
 	assert.Len(t, mock.durations, 1)
 	assert.Equal(t, "unmatched", mock.durations[0].route)
+}
+
+func TestMiddlewareRecordsRequest(t *testing.T) {
+	mock := &mockRecorder{}
+	router := setupTestRouter(mock)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/models", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Len(t, mock.requests, 1)
+	assert.Greater(t, mock.requests[0].duration, time.Duration(0))
 }

--- a/maas-api/internal/metrics/server_test.go
+++ b/maas-api/internal/metrics/server_test.go
@@ -72,4 +72,9 @@ func TestMetricsServerIntegration(t *testing.T) {
 
 	assert.Contains(t, bodyStr, `maas_api_http_requests_total{method="GET",route="/v1/models",status="200",tenant_name="test-tenant"} 1`)
 	assert.Contains(t, bodyStr, "maas_api_http_request_duration_seconds")
+
+	// Verify new metrics are also present
+	assert.Contains(t, bodyStr, `maas_requests_total 1`)
+	assert.Contains(t, bodyStr, "maas_request_duration_seconds")
+	assert.Contains(t, bodyStr, "maas_request_rejections_total")
 }

--- a/maas-api/internal/subscription/handler.go
+++ b/maas-api/internal/subscription/handler.go
@@ -6,24 +6,32 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/token"
 )
+
+// MetricsRecorder is the subset of metrics.MetricsRecorder used by this handler.
+type MetricsRecorder interface {
+	RecordRejection(reason string)
+}
 
 // Handler handles subscription selection requests.
 type Handler struct {
 	selector *Selector
 	logger   *logger.Logger
+	metrics  MetricsRecorder
 }
 
 // NewHandler creates a new subscription handler.
-func NewHandler(log *logger.Logger, selector *Selector) *Handler {
+func NewHandler(log *logger.Logger, selector *Selector, metrics MetricsRecorder) *Handler {
 	if log == nil {
 		log = logger.Production()
 	}
 	return &Handler{
 		selector: selector,
 		logger:   log,
+		metrics:  metrics,
 	}
 }
 
@@ -80,6 +88,7 @@ func (h *Handler) SelectSubscription(c *gin.Context) {
 		var modelUnhealthyErr *ModelUnhealthyError
 
 		if errors.As(err, &noSubErr) {
+			h.recordRejection(constant.RejectionNoCapacity)
 			h.logger.Debug("No subscription found for user",
 				"username", logger.RedactValue(req.Username),
 				"groups", req.Groups,
@@ -92,6 +101,7 @@ func (h *Handler) SelectSubscription(c *gin.Context) {
 		}
 
 		if errors.As(err, &notFoundErr) {
+			h.recordRejection(constant.RejectionNoCapacity)
 			h.logger.Debug("Requested subscription not found",
 				"subscription", req.RequestedSubscription,
 			)
@@ -103,6 +113,7 @@ func (h *Handler) SelectSubscription(c *gin.Context) {
 		}
 
 		if errors.As(err, &accessDeniedErr) {
+			h.recordRejection(constant.RejectionUnauthorized)
 			h.logger.Debug("Access denied to subscription",
 				"username", logger.RedactValue(req.Username),
 				"subscription", req.RequestedSubscription,
@@ -127,6 +138,7 @@ func (h *Handler) SelectSubscription(c *gin.Context) {
 		}
 
 		if errors.As(err, &modelNotInSubErr) {
+			h.recordRejection(constant.RejectionNoCapacity)
 			h.logger.Debug("Model not included in subscription",
 				"subscription", modelNotInSubErr.Subscription,
 				"model", modelNotInSubErr.Model,
@@ -139,6 +151,7 @@ func (h *Handler) SelectSubscription(c *gin.Context) {
 		}
 
 		if errors.As(err, &modelUnhealthyErr) {
+			h.recordUnhealthyRejection(modelUnhealthyErr)
 			h.logger.Debug("Requested model is unhealthy",
 				"subscription", modelUnhealthyErr.Subscription,
 				"phase", modelUnhealthyErr.Phase,
@@ -264,4 +277,21 @@ func (h *Handler) ListSubscriptionsForModel(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, subs)
+}
+
+func (h *Handler) recordRejection(reason string) {
+	if h.metrics != nil {
+		h.metrics.RecordRejection(reason)
+	}
+}
+
+func (h *Handler) recordUnhealthyRejection(err *ModelUnhealthyError) {
+	switch {
+	case err.Reason == "RateLimitNotEnforced":
+		h.recordRejection(constant.RejectionRateLimited)
+	case err.Phase == PhaseFailed:
+		h.recordRejection(constant.RejectionQuotaExceeded)
+	default:
+		h.recordRejection(constant.RejectionNoCapacity)
+	}
 }

--- a/maas-api/internal/subscription/handler_test.go
+++ b/maas-api/internal/subscription/handler_test.go
@@ -76,13 +76,25 @@ func createTestSubscription(name string, groups []string, priority int32, orgID,
 	}
 }
 
+type mockMetricsRecorder struct {
+	rejections []string
+}
+
+func (m *mockMetricsRecorder) RecordRejection(reason string) {
+	m.rejections = append(m.rejections, reason)
+}
+
 func setupTestRouter(lister subscription.Lister) *gin.Engine {
+	return setupTestRouterWithMetrics(lister, nil)
+}
+
+func setupTestRouterWithMetrics(lister subscription.Lister, metrics subscription.MetricsRecorder) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
 	log := logger.New(false)
 	selector := subscription.NewSelector(log, lister, nil, nil)
-	handler := subscription.NewHandler(log, selector)
+	handler := subscription.NewHandler(log, selector, metrics)
 
 	router.POST("/subscriptions/select", handler.SelectSubscription)
 	return router
@@ -1011,7 +1023,7 @@ func setupListTestRouterWithModels(lister subscription.Lister, modelLister model
 
 	log := logger.New(false)
 	selector := subscription.NewSelector(log, lister, modelLister, nil)
-	handler := subscription.NewHandler(log, selector)
+	handler := subscription.NewHandler(log, selector, nil)
 
 	setUser := func(c *gin.Context) {
 		c.Set("user", &token.UserContext{
@@ -1257,7 +1269,7 @@ func TestListSubscriptions_NoAuthContext(t *testing.T) {
 		createTestSubscription("premium-sub", []string{"premium-users"}, 10, "org-1", "cc-1"),
 	}}
 	selector := subscription.NewSelector(log, lister, nil, nil)
-	handler := subscription.NewHandler(log, selector)
+	handler := subscription.NewHandler(log, selector, nil)
 
 	tokenHandler := token.NewHandler(log, "test-tenant")
 
@@ -1494,5 +1506,154 @@ func TestListSubscriptionsForModel_NoAccess(t *testing.T) {
 
 	if len(result) != 0 {
 		t.Errorf("expected empty array when user has no access, got %d items", len(result))
+	}
+}
+
+func TestHandler_SelectSubscription_RecordsUnauthorizedRejection(t *testing.T) {
+	subscriptions := []*unstructured.Unstructured{
+		createTestSubscription("premium-sub", []string{"premium-users"}, 10, "org-1", "cc-1"),
+	}
+
+	metrics := &mockMetricsRecorder{}
+	lister := &mockLister{subscriptions: subscriptions}
+	router := setupTestRouterWithMetrics(lister, metrics)
+
+	reqBody := `{
+		"username": "alice",
+		"groups": ["basic-users"],
+		"requestedSubscription": "premium-sub"
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/select", bytes.NewBufferString(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if len(metrics.rejections) != 1 {
+		t.Fatalf("expected 1 rejection recorded, got %d", len(metrics.rejections))
+	}
+	if metrics.rejections[0] != "unauthorized" {
+		t.Errorf("expected rejection reason 'unauthorized', got %s", metrics.rejections[0])
+	}
+}
+
+func TestHandler_SelectSubscription_RecordsNoCapacityRejection(t *testing.T) {
+	// Empty subscription list
+	metrics := &mockMetricsRecorder{}
+	lister := &mockLister{subscriptions: []*unstructured.Unstructured{}}
+	router := setupTestRouterWithMetrics(lister, metrics)
+
+	reqBody := `{
+		"username": "alice",
+		"groups": ["basic-users"]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/select", bytes.NewBufferString(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if len(metrics.rejections) != 1 {
+		t.Fatalf("expected 1 rejection recorded, got %d", len(metrics.rejections))
+	}
+	if metrics.rejections[0] != "no-capacity" {
+		t.Errorf("expected rejection reason 'no-capacity', got %s", metrics.rejections[0])
+	}
+}
+
+func TestHandler_SelectSubscription_RecordsNoCapacityForModelNotInSubscription(t *testing.T) {
+	subscriptions := []*unstructured.Unstructured{
+		createTestSubscription("basic-sub", []string{"basic-users"}, 10, "org-1", "cc-1"),
+	}
+
+	metrics := &mockMetricsRecorder{}
+	lister := &mockLister{subscriptions: subscriptions}
+	router := setupTestRouterWithMetrics(lister, metrics)
+
+	reqBody := `{
+		"username": "alice",
+		"groups": ["basic-users"],
+		"requestedModel": "test-ns/nonexistent-model"
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/select", bytes.NewBufferString(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if len(metrics.rejections) != 1 {
+		t.Fatalf("expected 1 rejection recorded, got %d", len(metrics.rejections))
+	}
+	if metrics.rejections[0] != "no-capacity" {
+		t.Errorf("expected rejection reason 'no-capacity', got %s", metrics.rejections[0])
+	}
+}
+
+func TestHandler_SelectSubscription_RecordsQuotaExceededForFailedPhase(t *testing.T) {
+	metrics := &mockMetricsRecorder{}
+	lister := &fakeLister{subscriptions: []*unstructured.Unstructured{
+		createSubscriptionWithHealth("failed-sub", []string{"basic-users"}, nil, 10, defaultTestTokenRateLimit, phaseFailed, false, false),
+	}}
+	router := setupTestRouterWithMetrics(lister, metrics)
+
+	reqBody := `{
+		"username": "alice",
+		"groups": ["basic-users"],
+		"requestedModel": "test-model"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/select", bytes.NewBufferString(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if len(metrics.rejections) != 1 {
+		t.Fatalf("expected 1 rejection recorded, got %d", len(metrics.rejections))
+	}
+	if metrics.rejections[0] != "quota-exceeded" {
+		t.Errorf("expected rejection reason 'quota-exceeded', got %s", metrics.rejections[0])
+	}
+}
+
+func TestHandler_SelectSubscription_RecordsRateLimitedForTRLPNotReady(t *testing.T) {
+	metrics := &mockMetricsRecorder{}
+	lister := &fakeLister{subscriptions: []*unstructured.Unstructured{
+		createSubscriptionWithTRLPStatus("degraded-sub", []string{"basic-users"}, phaseDegraded, []map[string]any{
+			{
+				"name":      "model-a",
+				"namespace": "ns",
+				"ready":     true,
+				"reason":    "Valid",
+			},
+		}, []map[string]any{
+			{
+				"model":     "model-a",
+				"name":      "maas-trlp-model-a",
+				"namespace": "ns",
+				"ready":     false,
+				"reason":    "NotAccepted",
+				"message":   "status not available",
+			},
+		}),
+	}}
+	router := setupTestRouterWithMetrics(lister, metrics)
+
+	reqBody := `{
+		"username": "alice",
+		"groups": ["basic-users"],
+		"requestedModel": "ns/model-a"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/select", bytes.NewBufferString(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if len(metrics.rejections) != 1 {
+		t.Fatalf("expected 1 rejection recorded, got %d", len(metrics.rejections))
+	}
+	if metrics.rejections[0] != "rate-limited" {
+		t.Errorf("expected rejection reason 'rate-limited', got %s", metrics.rejections[0])
 	}
 }


### PR DESCRIPTION
## Summary
- Cherry-pick of [opendatahub-io/models-as-a-service#1415](https://github.com/opendatahub-io/models-as-a-service/pull/1415) (`34a9e01`) onto `rhoai-3.6-ea.1`
- Adds unlabeled `maas_requests_total` and `maas_request_duration_seconds` plus `maas_request_rejections_total{reason=rate-limited|unauthorized|no-capacity|quota-exceeded}` on the existing maas-api `/metrics` endpoint
- Tracker: [RHOAIENG-84614](https://redhat.atlassian.net/browse/RHOAIENG-84614)

Applied cleanly with no conflicts.



