### PR TITLE
Migrate runtime base image to PQC variant for main

### DIFF
--- a/maas-api/Dockerfile.konflux
+++ b/maas-api/Dockerfile.konflux
@@ -14,7 +14,7 @@ COPY . .
 USER root
 RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o maas-api ./cmd/
 
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7fbeae18dc9476399f565e68255f602a3374ea8614ba3d14843565131a13ff93
+FROM --platform=$TARGETPLATFORM registry.redhat.io/ubi9/ubi-minimal-pqc@sha256:8a842ac769de709143e4edeace516f2008dfdc431b64670ad3353fa323b44736
 
 WORKDIR /app
 

--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -15,7 +15,7 @@ COPY maas-controller/ ./
 USER root
 RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
 
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7fbeae18dc9476399f565e68255f602a3374ea8614ba3d14843565131a13ff93
+FROM --platform=$TARGETPLATFORM registry.redhat.io/ubi9/ubi-minimal-pqc@sha256:8a842ac769de709143e4edeace516f2008dfdc431b64670ad3353fa323b44736
 
 WORKDIR /
 


### PR DESCRIPTION
## Summary

This PR migrates the runtime base image from `registry.access.redhat.com/ubi9/ubi-minimal` to `registry.redhat.io/ubi9/ubi-minimal-pqc@sha256:8a842ac769de709143e4edeace516f2008dfdc431b64670ad3353fa323b44736` for RHOAI $BRANCH.

## Changes

- Updated runtime `FROM` statements in Dockerfiles
- Updated `ARG` variable default values where applicable
- Preserved existing tags and digests

## Rationale

The PQC (Post-Quantum Cryptography) variant provides enhanced cryptographic security for future-proofing against quantum computing threats.
Jira => https://redhat.atlassian.net/browse/RHOAIENG-90799

## Testing
PR => https://github.com/red-hat-data-services/models-as-a-service/pull/748
