### PR TITLE
chore: update go mod to 1.25.13

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/models-as-a-service/maas-api
 
-go 1.25.0
+go 1.25.13
 
 require (
 	github.com/gin-contrib/cors v1.7.6


### PR DESCRIPTION
## Description:

### Related to: https://redhat.atlassian.net/browse/RHOAIENG-87105

encoding/xml is in the dependency tree - pulled in via the AWS SDK. The DecodeElement code path is reachable. This CVE is not false positive. The scanner is flagging this correctly. Anyone building outside Konflux (local dev, non-Konflux CI, the non-Konflux Dockerfile) would use a vulnerable Go version. The Konflux image digest is not the authoritative enforcement - go.mod is.

The following change targets a fix for the aformentioned issue with the `go.mod` change to go **1.25.13** thanks to the fact that we have  `GOTOOLCHAIN=auto default`, which means the build will auto-download `Go 1.25.13` at compile time regardless of the base image's bundled Go version. The compiled binary will use the patched `encoding/xml` from 1.25.13. Additionally, The Konflux Dockerfile digest on rhoai-3.3 (sha256:8cf89835...) already contains Go 1.26.7 as well. 