### PR TITLE
chore(RHOAIENG-89628): cherry-pick legacy ExternalModel migration fixes to rhoai-3.5

### DIFF
--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
@@ -161,12 +161,19 @@ spec:
                   - type
                   type: object
                 type: array
+              message:
+                description: Message provides details about the current phase.
+                type: string
               phase:
-                description: Phase represents the current phase of the external model
+                description: |-
+                  Phase represents the current phase of the external model
+                  Migrated means networking is managed by the corresponding
+                  inference.opendatahub.io ExternalModel.
                 enum:
                 - Pending
                 - Ready
                 - Failed
+                - Migrated
                 type: string
             type: object
         required:

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -298,6 +298,7 @@ rules:
   - maas.opendatahub.io
   resources:
   - aitenants/status
+  - externalmodels/status
   - maasauthpolicies/status
   - maasmodelrefs/status
   - maassubscriptions/status

--- a/maas-controller/api/maas/v1alpha1/externalmodel_types.go
+++ b/maas-controller/api/maas/v1alpha1/externalmodel_types.go
@@ -83,8 +83,14 @@ type CredentialReference struct {
 // ExternalModelStatus defines the observed state of ExternalModel
 type ExternalModelStatus struct {
 	// Phase represents the current phase of the external model
-	// +kubebuilder:validation:Enum=Pending;Ready;Failed
+	// Migrated means networking is managed by the corresponding
+	// inference.opendatahub.io ExternalModel.
+	// +kubebuilder:validation:Enum=Pending;Ready;Failed;Migrated
 	Phase string `json:"phase,omitempty"`
+
+	// Message provides details about the current phase.
+	// +optional
+	Message string `json:"message,omitempty"`
 
 	// Conditions represent the latest available observations of the external model's state
 	// +optional

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler.go
@@ -108,6 +108,7 @@ func getTLSInfo(extModel *maasv1alpha1.ExternalModel) (tls bool, port int32, err
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels,verbs=get;list;watch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels/finalizers,verbs=update
+//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=networking.istio.io,resources=serviceentries,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;update;delete
@@ -136,7 +137,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	} else if superseded {
 		log.FromContext(ctx).Info("inference ExternalModel exists, tearing down legacy networking",
 			"name", req.Name, "namespace", req.Namespace)
-		return r.teardownLegacyChildren(ctx, extModel)
+		if _, err := r.teardownLegacyChildren(ctx, extModel); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, r.markMigrated(ctx, extModel)
 	}
 
 	tls, port, err := getTLSInfo(extModel)
@@ -398,6 +402,23 @@ func (r *Reconciler) teardownLegacyChildren(ctx context.Context, extModel *maasv
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// markMigrated records that the inference API now owns networking for this
+// legacy ExternalModel. The legacy object remains as the owner of the migrated
+// inference resources, so the status gives users a durable migration signal.
+func (r *Reconciler) markMigrated(ctx context.Context, extModel *maasv1alpha1.ExternalModel) error {
+	desiredMessage := fmt.Sprintf("Model migrated to inference.opendatahub.io ExternalModel: %s", extModel.Name)
+	if extModel.Status.Phase == "Migrated" && extModel.Status.Message == desiredMessage {
+		return nil
+	}
+
+	extModel.Status.Phase = "Migrated"
+	extModel.Status.Message = desiredMessage
+	if err := r.Status().Update(ctx, extModel); err != nil {
+		return fmt.Errorf("failed to mark legacy ExternalModel %s/%s as migrated: %w", extModel.Namespace, extModel.Name, err)
+	}
+	return nil
 }
 
 // SetupWithManager registers the reconciler to watch ExternalModel CRs.

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,7 +18,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
@@ -32,6 +35,12 @@ const (
 	// annotationTLS controls TLS origination (default "true").
 	annotationTLS = "maas.opendatahub.io/tls"
 )
+
+var inferenceExternalModelGVK = schema.GroupVersionKind{
+	Group:   "inference.opendatahub.io",
+	Version: "v1alpha1",
+	Kind:    "ExternalModel",
+}
 
 // Reconciler watches ExternalModel CRs and creates the Istio resources
 // needed to route to the external provider.
@@ -118,6 +127,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Nothing to do on deletion — OwnerReferences handle cleanup
 	if !extModel.GetDeletionTimestamp().IsZero() {
 		return ctrl.Result{}, nil
+	}
+
+	// If an inference.opendatahub.io ExternalModel exists for this model,
+	// the IPP controller owns networking. Tear down legacy maas-* children.
+	if superseded, err := r.isSupersededByInference(ctx, req.NamespacedName); err != nil {
+		return ctrl.Result{}, err
+	} else if superseded {
+		log.FromContext(ctx).Info("inference ExternalModel exists, tearing down legacy networking",
+			"name", req.Name, "namespace", req.Namespace)
+		return r.teardownLegacyChildren(ctx, extModel)
 	}
 
 	tls, port, err := getTLSInfo(extModel)
@@ -313,10 +332,111 @@ func (r *Reconciler) applyHTTPRoute(ctx context.Context, log logr.Logger, desire
 	return r.Update(ctx, existing)
 }
 
+// isSupersededByInference reports whether an inference.opendatahub.io ExternalModel
+// exists for the same name/namespace AND has published its HTTPRoute
+// (status.httpRouteName is set), meaning the IPP controller now owns networking.
+//
+// Teardown is gated on that readiness signal, not on mere existence: if we removed
+// the legacy maas-* route the moment the inference CR appeared — before its route is
+// programmed — there would be a window with no route for the model, causing a
+// routing/auth gap during the migration cutover. The MaaSModelRef handler waits for
+// the same signal (see providers_external.go), so this keeps the two in lockstep.
+//
+// When the inference CRD is not installed (IsNoMatchError), the legacy reconciler
+// proceeds normally, so pure 3.4 clusters are unaffected.
+func (r *Reconciler) isSupersededByInference(ctx context.Context, key types.NamespacedName) (bool, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(inferenceExternalModelGVK)
+	if err := r.Get(ctx, key, obj); err != nil {
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check inference ExternalModel %s/%s: %w", key.Namespace, key.Name, err)
+	}
+	routeName, _, err := unstructured.NestedString(obj.Object, "status", "httpRouteName")
+	if err != nil {
+		return false, fmt.Errorf("failed to read status.httpRouteName on inference ExternalModel %s/%s: %w", key.Namespace, key.Name, err)
+	}
+	return routeName != "", nil
+}
+
+// teardownLegacyChildren deletes the maas-* networking resources (Service,
+// ServiceEntry, DestinationRule, HTTPRoute) that were created by this reconciler
+// for the given ExternalModel, then returns a no-requeue result.
+func (r *Reconciler) teardownLegacyChildren(ctx context.Context, extModel *maasv1alpha1.ExternalModel) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	resourceName := modelnaming.ExternalModelResourceName(extModel.Name)
+	ns := extModel.Namespace
+
+	if err := r.deleteIfExists(ctx, logger, "HTTPRoute", resourceName, ns, schema.GroupVersionKind{
+		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute",
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete legacy HTTPRoute: %w", err)
+	}
+	if err := r.deleteIfExists(ctx, logger, "DestinationRule", resourceName, ns, schema.GroupVersionKind{
+		Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule",
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete legacy DestinationRule: %w", err)
+	}
+	if err := r.deleteIfExists(ctx, logger, "ServiceEntry", resourceName, ns, schema.GroupVersionKind{
+		Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete legacy ServiceEntry: %w", err)
+	}
+
+	svc := &corev1.Service{}
+	svcKey := types.NamespacedName{Name: resourceName, Namespace: ns}
+	if err := r.Get(ctx, svcKey, svc); err == nil {
+		if isManaged(svc) {
+			logger.Info("Deleting legacy Service", "name", resourceName)
+			if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to delete legacy Service: %w", err)
+			}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("failed to get legacy Service: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
 // SetupWithManager registers the reconciler to watch ExternalModel CRs.
+//
+// It additionally watches inference.opendatahub.io ExternalModels so that when the
+// legacy-migration controller creates the canonical CR, the matching legacy
+// ExternalModel is re-reconciled promptly and its maas-* networking is torn down —
+// rather than waiting for the periodic resync (which can be hours). Each inference
+// event is mapped to the same name/namespace; Reconcile then no-ops if no legacy
+// ExternalModel exists there, so native inference-only models are never affected.
+//
+// The watch is only wired when the inference CRD is installed. On pure 3.4 clusters
+// the CRD is absent and establishing an informer for it would fail cache sync, so we
+// skip it; there is no inference CR to react to on those clusters anyway.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&maasv1alpha1.ExternalModel{}).
-		Named("external-model-reconciler").
-		Complete(r)
+		Named("external-model-reconciler")
+
+	if _, err := mgr.GetRESTMapper().RESTMapping(
+		inferenceExternalModelGVK.GroupKind(), inferenceExternalModelGVK.Version,
+	); err == nil {
+		inferenceEM := &unstructured.Unstructured{}
+		inferenceEM.SetGroupVersionKind(inferenceExternalModelGVK)
+		b = b.Watches(inferenceEM, handler.EnqueueRequestsFromMapFunc(
+			func(_ context.Context, obj client.Object) []reconcile.Request {
+				return []reconcile.Request{{
+					NamespacedName: types.NamespacedName{
+						Name:      obj.GetName(),
+						Namespace: obj.GetNamespace(),
+					},
+				}}
+			},
+		))
+	} else {
+		mgr.GetLogger().Info("inference.opendatahub.io ExternalModel CRD not installed; "+
+			"skipping supersede watch (legacy ExternalModel reconciler runs unchanged)",
+			"gvk", inferenceExternalModelGVK.String())
+	}
+
+	return b.Complete(r)
 }

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler_test.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler_test.go
@@ -371,6 +371,7 @@ func TestReconcile_SupersededByInference(t *testing.T) {
 	inferenceEM := newInferenceExternalModel(name, ns, resourceName)
 
 	c := fake.NewClientBuilder().WithScheme(testScheme).
+		WithStatusSubresource(&maasv1alpha1.ExternalModel{}).
 		WithObjects(em, legacySvc, legacyHR).
 		WithObjects(inferenceEM).
 		Build()
@@ -392,6 +393,13 @@ func TestReconcile_SupersededByInference(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(
 		c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotHR)),
 		"expected legacy HTTPRoute to be deleted")
+
+	// Legacy ExternalModel remains as owner of the inference resources and
+	// exposes a durable signal that migration completed.
+	gotEM := &maasv1alpha1.ExternalModel{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, gotEM))
+	assert.Equal(t, "Migrated", gotEM.Status.Phase)
+	assert.Equal(t, "Model migrated to inference.opendatahub.io ExternalModel: gpt-4o", gotEM.Status.Message)
 }
 
 // TestReconcile_NoInferenceModel_ProceedsNormally verifies that without an
@@ -484,6 +492,7 @@ func TestReconcile_SupersededDoesNotTeardownOptedOut(t *testing.T) {
 	inferenceEM := newInferenceExternalModel(name, ns, resourceName)
 
 	c := fake.NewClientBuilder().WithScheme(testScheme).
+		WithStatusSubresource(&maasv1alpha1.ExternalModel{}).
 		WithObjects(em, legacySvc).
 		WithObjects(inferenceEM).
 		Build()

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler_test.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler_test.go
@@ -327,6 +327,179 @@ func TestManagedAnnotation_DestinationRule_DeletePath(t *testing.T) {
 	}
 }
 
+// newInferenceExternalModel creates a minimal inference.opendatahub.io ExternalModel
+// as an unstructured object for testing the supersede check. When routeName is
+// non-empty it is set on status.httpRouteName, marking the inference route as
+// programmed (Ready) — the signal that gates legacy teardown.
+func newInferenceExternalModel(name, ns, routeName string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "inference.opendatahub.io/v1alpha1",
+		"kind":       "ExternalModel",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": ns,
+		},
+	}}
+	if routeName != "" {
+		obj.Object["status"] = map[string]any{"httpRouteName": routeName}
+	}
+	return obj
+}
+
+// TestReconcile_SupersededByInference verifies that when an inference.opendatahub.io
+// ExternalModel exists, the legacy reconciler tears down its maas-* children
+// instead of creating/updating them.
+func TestReconcile_SupersededByInference(t *testing.T) {
+	const (
+		name     = "gpt-4o"
+		ns       = "llm"
+		endpoint = "api.openai.com"
+	)
+	resourceName := modelnaming.ExternalModelResourceName(name)
+
+	// Pre-populate legacy children that should be torn down.
+	legacySvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeExternalName, ExternalName: endpoint},
+	}
+	legacyHR := &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+		Spec:       gatewayapiv1.HTTPRouteSpec{},
+	}
+
+	em := newTestExternalModel(name, ns, endpoint, nil)
+	inferenceEM := newInferenceExternalModel(name, ns, resourceName)
+
+	c := fake.NewClientBuilder().WithScheme(testScheme).
+		WithObjects(em, legacySvc, legacyHR).
+		WithObjects(inferenceEM).
+		Build()
+	r := &Reconciler{Client: c, Scheme: testScheme, Log: ctrl.Log}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: ns},
+	})
+	require.NoError(t, err)
+
+	// Legacy Service should be deleted.
+	gotSvc := &corev1.Service{}
+	assert.True(t, apierrors.IsNotFound(
+		c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotSvc)),
+		"expected legacy Service to be deleted")
+
+	// Legacy HTTPRoute should be deleted.
+	gotHR := &gatewayapiv1.HTTPRoute{}
+	assert.True(t, apierrors.IsNotFound(
+		c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotHR)),
+		"expected legacy HTTPRoute to be deleted")
+}
+
+// TestReconcile_NoInferenceModel_ProceedsNormally verifies that without an
+// inference.opendatahub.io ExternalModel, the reconciler creates children as usual.
+func TestReconcile_NoInferenceModel_ProceedsNormally(t *testing.T) {
+	const (
+		name     = "gpt-4o"
+		ns       = "llm"
+		endpoint = "api.openai.com"
+	)
+
+	em := newTestExternalModel(name, ns, endpoint, nil)
+	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(em).Build()
+	r := &Reconciler{Client: c, Scheme: testScheme, Log: ctrl.Log, GatewayName: "maas-gw", GatewayNamespace: "ingress"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: ns},
+	})
+	require.NoError(t, err)
+
+	resourceName := modelnaming.ExternalModelResourceName(name)
+
+	// Service should be created.
+	gotSvc := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotSvc))
+	assert.Equal(t, endpoint, gotSvc.Spec.ExternalName)
+
+	// HTTPRoute should be created.
+	gotHR := &gatewayapiv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotHR))
+}
+
+// TestReconcile_InferenceNotReady_ProceedsNormally verifies that when an
+// inference.opendatahub.io ExternalModel exists but has not yet published its
+// HTTPRoute (status.httpRouteName unset), the legacy reconciler does NOT tear down
+// its children — avoiding a routing gap before the replacement route is programmed.
+func TestReconcile_InferenceNotReady_ProceedsNormally(t *testing.T) {
+	const (
+		name     = "gpt-4o"
+		ns       = "llm"
+		endpoint = "api.openai.com"
+	)
+	resourceName := modelnaming.ExternalModelResourceName(name)
+
+	em := newTestExternalModel(name, ns, endpoint, nil)
+	// Inference CR exists but is not Ready yet (no status.httpRouteName).
+	inferenceEM := newInferenceExternalModel(name, ns, "")
+
+	c := fake.NewClientBuilder().WithScheme(testScheme).
+		WithObjects(em).
+		WithObjects(inferenceEM).
+		Build()
+	r := &Reconciler{Client: c, Scheme: testScheme, Log: ctrl.Log, GatewayName: "maas-gw", GatewayNamespace: "ingress"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: ns},
+	})
+	require.NoError(t, err)
+
+	// Legacy children should still be created, since the inference route is not live.
+	gotSvc := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotSvc),
+		"expected legacy Service to be created while inference route is not Ready")
+
+	gotHR := &gatewayapiv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotHR),
+		"expected legacy HTTPRoute to be created while inference route is not Ready")
+}
+
+// TestReconcile_SupersededDoesNotTeardownOptedOut verifies that teardown
+// respects the opendatahub.io/managed=false annotation on legacy children.
+func TestReconcile_SupersededDoesNotTeardownOptedOut(t *testing.T) {
+	const (
+		name     = "gpt-4o"
+		ns       = "llm"
+		endpoint = "api.openai.com"
+	)
+	resourceName := modelnaming.ExternalModelResourceName(name)
+
+	legacySvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        resourceName,
+			Namespace:   ns,
+			Annotations: map[string]string{tenantreconcile.AnnotationManaged: "false"},
+		},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeExternalName, ExternalName: endpoint},
+	}
+
+	em := newTestExternalModel(name, ns, endpoint, nil)
+	inferenceEM := newInferenceExternalModel(name, ns, resourceName)
+
+	c := fake.NewClientBuilder().WithScheme(testScheme).
+		WithObjects(em, legacySvc).
+		WithObjects(inferenceEM).
+		Build()
+	r := &Reconciler{Client: c, Scheme: testScheme, Log: ctrl.Log}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: ns},
+	})
+	require.NoError(t, err)
+
+	// Service with managed=false should survive.
+	gotSvc := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotSvc),
+		"expected opted-out Service to survive teardown")
+}
+
 // TestIsManaged verifies the isManaged helper function covers all edge cases.
 func TestIsManaged(t *testing.T) {
 	tests := []struct {

--- a/test/e2e/tests/test_external_models.py
+++ b/test/e2e/tests/test_external_models.py
@@ -24,6 +24,7 @@ import logging
 import os
 import subprocess
 import time
+import uuid
 
 import pytest
 import requests
@@ -408,6 +409,88 @@ requires_ipp = pytest.mark.skipif(
     not _check_ipp_pods_deployed(),
     reason="Payload-processing (IPP) pods not deployed; body routing tests require IPP",
 )
+
+
+@requires_ipp
+class TestLegacyExternalModelMigration:
+    """Verify IPP migration is reflected on the retained legacy CR."""
+
+    def test_migration_sets_legacy_status_and_removes_networking(self):
+        name = f"e2e-legacy-migration-{uuid.uuid4().hex[:8]}"
+        secret_name = f"{name}-api-key"
+        legacy_kind = "externalmodels.maas.opendatahub.io"
+        legacy_resource_name = f"maas-{name}"
+        expected_message = f"Model migrated to inference.opendatahub.io ExternalModel: {name}"
+        deadline = time.monotonic() + 180
+
+        try:
+            _apply_cr({
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {"name": secret_name, "namespace": MODEL_NAMESPACE},
+                "type": "Opaque",
+                "stringData": {"api-key": "e2e-test-key"},
+            })
+            # Seed one legacy networking child so this test proves teardown ran,
+            # even if IPP migrates the model before the legacy reconciler has
+            # time to create the full networking set.
+            _apply_cr({
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {"name": legacy_resource_name, "namespace": MODEL_NAMESPACE},
+                "spec": {
+                    "type": "ExternalName",
+                    "externalName": EXTERNAL_ENDPOINT,
+                    "ports": [{"name": "https", "port": 443}],
+                },
+            })
+            _apply_cr({
+                "apiVersion": "maas.opendatahub.io/v1alpha1",
+                "kind": "ExternalModel",
+                "metadata": {"name": name, "namespace": MODEL_NAMESPACE},
+                "spec": {
+                    "provider": "openai",
+                    "targetModel": TARGET_MODEL,
+                    "endpoint": EXTERNAL_ENDPOINT,
+                    "credentialRef": {"name": secret_name},
+                },
+            })
+
+            legacy = None
+            inference = None
+            while time.monotonic() < deadline:
+                legacy = _get_cr(legacy_kind, name, MODEL_NAMESPACE)
+                inference = _get_cr(EXTERNAL_MODEL_KIND, name, MODEL_NAMESPACE)
+                if (
+                    legacy
+                    and legacy.get("status", {}).get("phase") == "Migrated"
+                    and inference
+                    and inference.get("status", {}).get("httpRouteName")
+                ):
+                    break
+                time.sleep(2)
+
+            assert inference is not None, "IPP did not create the inference ExternalModel"
+            assert inference.get("status", {}).get("httpRouteName"), (
+                "Migrated inference ExternalModel did not publish status.httpRouteName"
+            )
+            assert legacy is not None, "Legacy ExternalModel was unexpectedly removed"
+            assert legacy.get("status", {}).get("phase") == "Migrated"
+            assert legacy.get("status", {}).get("message") == expected_message
+
+            assert _get_cr("httproute", legacy_resource_name, MODEL_NAMESPACE) is None, (
+                f"Legacy HTTPRoute {legacy_resource_name} was not removed"
+            )
+            assert _get_cr("service", legacy_resource_name, MODEL_NAMESPACE) is None, (
+                f"Legacy Service {legacy_resource_name} was not removed"
+            )
+        finally:
+            # The legacy CR owns the inference resources created by the migration
+            # controller, so deleting it should garbage-collect those children.
+            _delete_cr(legacy_kind, name, MODEL_NAMESPACE)
+            _delete_cr(EXTERNAL_MODEL_KIND, name, MODEL_NAMESPACE)
+            _delete_cr("service", legacy_resource_name, MODEL_NAMESPACE)
+            _delete_cr("secret", secret_name, MODEL_NAMESPACE)
 
 
 @requires_ipp


### PR DESCRIPTION
## Summary

Cherry-pick of two upstream MaaS commits onto `rhoai-3.5`:

| Upstream PR | Commit | Description |
|-------------|--------|-------------|
| [opendatahub-io/models-as-a-service#1417](https://github.com/opendatahub-io/models-as-a-service/pull/1417) | `48261f4d` | Stop legacy `ExternalModel` reconciler when inference `ExternalModel` exists and route is programmed (`status.httpRouteName` set); tear down `maas-*` networking children and watch inference CRs for prompt teardown |
| [opendatahub-io/models-as-a-service#1437](https://github.com/opendatahub-io/models-as-a-service/pull/1437) | `f47c07e0` | Add `Migrated` phase and status message to legacy `ExternalModel` CRs after migration completes |

**Jira:** [RHOAIENG-89628](https://redhat.atlassian.net/browse/RHOAIENG-89628)

### Why

- On 3.4→3.5 upgrades, the legacy migration controller creates `inference.opendatahub.io` ExternalModel/ExternalProvider CRs but leaves the `maas.opendatahub.io` ExternalModel in place.
- Both the maas-controller legacy reconciler and the IPP controller then create parallel networking resources for the same model, causing duplicate HTTPRoutes, TRLP ownership conflicts, and policy skew.
- Operators had no status signal on legacy ExternalModels to tell whether a model was still active or already migrated to inference.

### Release notes

- Legacy `maas-*` networking resources are removed once the inference route is programmed.
- Legacy `ExternalModel` status reports `phase: Migrated` with a message identifying the inference replacement.

## Test plan

- [x] Cherry-picks applied cleanly onto `rhoai-3.5`
- [x] `go test ./pkg/reconciler/externalmodel/... -count=1` passes locally
- [ ] CI green on downstream PR
- [ ] Validate 3.4→3.5 upgrade flow: legacy networking torn down after inference route is programmed; legacy `ExternalModel` status shows `Migrated` 